### PR TITLE
luci-app-ffwizard-berlin: change static dns in wizzard

### DIFF
--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -195,6 +195,9 @@ function main.write(self, section, value)
   --NETWORK CONFIG remove lan bridge because ports a part of dhcp bridge now
   uci:delete("network", "lan")
 
+  --DHCP CONFIG change ip of frei.funk domain
+  uci:set("dhcp", "frei_funk", "ip", dhcpmeshnet:minhost():string())
+
   --DHCP CONFIG bridge for wifi APs
   local dhcpbase = uci:get_all("freifunk", "dhcp") or {}
   util.update(dhcpbase, uci:get_all(community, "dhcp") or {})

--- a/utils/luci-app-ffwizard-berlin/root/etc/uci-defaults/wizarddefaults
+++ b/utils/luci-app-ffwizard-berlin/root/etc/uci-defaults/wizarddefaults
@@ -5,9 +5,9 @@ uci set network.lan.ipaddr=192.168.42.1
 uci commit network
 
 #set dns name frei.funk
-DOMAIN="$(uci add dhcp domain)"
-uci set dhcp.$DOMAIN.name=frei.funk
-uci set dhcp.$DOMAIN.ip=192.168.42.1
+uci set dhcp.frei_funk=domain
+uci set dhcp.frei_funk.name=frei.funk
+uci set dhcp.frei_funk.ip=192.168.42.1
 uci commit dhcp
 
 #configure olsr jsoninfo plugin


### PR DESCRIPTION
This static dns entry frei.funk becomes the min. ip of the dhcp
network aka the router ip. We use a named uci section with underscore instead of
dot because this fixes a syntax problem. We need a named section to access the
section through the wizzard.

Closes freifunk-berlin/firmware#16

@geirkairam could you have a look/test? Thanks!
