### PR TITLE
ffizward-berlin: remove obsolete parameters

### DIFF
--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -129,7 +129,6 @@ function main.write(self, section, value)
       devconfig.hwmode = calchwmode(device)
       devconfig.doth = calcdoth(devconfig.channel)
       devconfig.htmode = calchtmode(devconfig.channel)
-      devconfig.country = 'DE'
       devconfig.chanlist = calcchanlist(devconfig.channel)
       uci:tset("wireless", device, devconfig)
 
@@ -137,7 +136,6 @@ function main.write(self, section, value)
       local ifconfig = uci:get_all("freifunk", "wifi_iface") or {}
       util.update(ifconfig, uci:get_all(community, "wifi_iface") or {})
       ifconfig.device = device
-      ifconfig.mcast_rate = ""
       ifconfig.network = calcnif(device)
       ifconfig.ifname = calcifcfg(device).."-".."adhoc".."-"..calcpre(devconfig.channel)
       ifconfig.mode = "adhoc"


### PR DESCRIPTION
mcast_rate and country should be set in community_profiles (like in http://luci.subsignal.org/trac/browser/luci/trunk/contrib/package/community-profiles/files/etc/config/profile_leipzig#L22) or via default packages.
