### PR TITLE
add package freifunk-berlin-freifunk-defaults

### DIFF
--- a/utils/freifunk-berlin-freifunk-defaults/Makefile
+++ b/utils/freifunk-berlin-freifunk-defaults/Makefile
@@ -1,0 +1,36 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=freifunk-berlin-freifunk-defaults
+PKG_VERSION:=0.0.1
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/freifunk-berlin-freifunk-defaults
+  SECTION:=freifunk-berlin
+  CATEGORY:=freifunk-berlin
+  TITLE:=Freifunk Berlin freifunk default configuration
+  URL:=http://github.com/freifunk-berlin/packages_berlin
+endef
+
+define Package/freifunk-berlin-freifunk-defaults/description
+  Freifunk Berlin configuration files for freifunk
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/freifunk-berlin-freifunk-defaults/install
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,freifunk-berlin-freifunk-defaults))

--- a/utils/freifunk-berlin-freifunk-defaults/files/etc/config/freifunk
+++ b/utils/freifunk-berlin-freifunk-defaults/files/etc/config/freifunk
@@ -1,0 +1,16 @@
+package 'freifunk'
+
+config 'public' 'contact'
+	option 'nickname' ''
+	option 'name' ''
+	option 'mail' ''
+	option 'phone' ''
+	option 'note' ''
+
+config 'public' 'community'
+	option 'name' 'Freifunk Berlin'
+	option 'homepage' 'http://berlin.freifunk.net'
+
+config 'defaults' 'system'
+	option 'zonename' 'Europe/Berlin'
+	option 'timezone' 'CET-1CES


### PR DESCRIPTION
default settings for /etc/config/freifunk - this makes freifunk-obsolete for us.
