### PR TITLE
[freifunk-berlin-openvpn-files] change routing table for default route o...

### DIFF
--- a/utils/freifunk-berlin-openvpn-files/openvpn/ffvpn-up.sh
+++ b/utils/freifunk-berlin-openvpn-files/openvpn/ffvpn-up.sh
@@ -25,7 +25,7 @@ if [ $enable != 1 ] ; then
 fi
 
 config_get strict pr strict
-table="olsr-default"
+table="olsr-tunnel"
 dev="$1"
 remote="$5"
 


### PR DESCRIPTION
...ver vpn

If we have a uplink via the ffvpn interface the default route should be in the
olsr-tunnel table instead of the olsr-default table. Otherwise the smart-gateway
ipip tunnel has a higher priority as the local default gateway. If this is the
case the kernel uses the default route from the olsr-tunnel table instead of the
route in the olsr-default table. This is due to the way we prioritise the
tables:

root@f2a-testing-2ghz:~# ip rule list
0:  from all lookup local
1000:   from all lookup olsr
2000:   from all lookup localnets
19999:  from all iif br-dhcp lookup olsr-tunnel
19999:  from all iif wlan0-adhoc-2 lookup olsr-tunnel
19999:  from all iif ffvpn lookup olsr-tunnel
20000:  from all iif wlan0-adhoc-2 lookup olsr-default
20000:  from all iif br-dhcp lookup olsr-default
20000:  from all iif tunl0 lookup olsr-default
20000:  from all iif ffvpn lookup olsr-default
20001:  from all iif wlan0-adhoc-2 unreachable
20001:  from all iif br-dhcp unreachable
20001:  from all iif tunl0 unreachable
20001:  from all iif ffvpn unreachable
32766:  from all lookup main
32767:  from all lookup default
100000: from all lookup olsr-tunnel
100010: from all lookup olsr-default

If we add the default route of ffvpn to the olsr-tunnel the route becomes higher
priority and the kernel chooses the ffvpn tunnel for package with destination
internet.

The related ticket is: https://github.com/freifunk-berlin/firmware/issues/112
