### PR TITLE
use HT20 for *all* wifi devices and channels

### DIFF
--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -307,6 +307,11 @@ end
 function calchtmode(channel)
   -- use HT20 for 2.4 GHz and channel 100+ for 5Ghz
   local htmode = "HT20"
+
+  -- TODO: remove the following line and uncomment the subsequent block once
+  -- HT40 works with ap+adhoc simultaneously in openwrt.
+  return htmode
+--[[
   local ht40plus = {
     1,2,3,4,5,6,7,
     36,44,52,60
@@ -330,6 +335,7 @@ function calchtmode(channel)
   end
 
   return htmode
+--]]
 end
 
 function get_iwinfo(device)


### PR DESCRIPTION
fixes freifunk-berlin/firmware#160
