### PR TITLE
[ffwizard] fix bug collectd does not start

### DIFF
--- a/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
@@ -117,15 +117,12 @@ function commit()
     local enableStats = uci:get("ffwizard", "settings", "enableStats") or "0"
     uci:foreach("luci_statistics", "statistics",
       function(s)
-        uci:set("luci_statistics", s['.name'], "enable", enableStats)
+        if (s['.name'] ~= 'collectd' and s['.name'] ~= 'rrdtool') then
+          uci:set("luci_statistics", s['.name'], "enable", enableStats)
+        end
       end)
     uci:save("luci_statistics")
     uci:commit("luci_statistics")
-    if (enableStats == "1") then
-      sys.init.enable("luci_statistics")
-    else
-      sys.init.disable("luci_statistics")
-    end
   end
 
   sys.hostname(uci:get_first("system","system","hostname"))

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/enableStats.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/enableStats.htm
@@ -1,5 +1,6 @@
 <div class="alert-message">
   <p class="info">
     Wenn Du hier den Haken setzt, werden statistische Daten &uuml;ber Deinen Router an <a href="http://monitor.berlin.freifunk.net">monitor.berlin.freifunk.net</a> geschickt und dort angezeigt.
+    Es werden keine Statistiken erhoben, wenn du den Haken nicht setzt. Du kannst die lokalen Statistiken sp&auml;ter &uuml;ber Administration &gt; Statistics &gt; Collectd einschalten.
   </p>
 </div>


### PR DESCRIPTION
Issue freifunk-berlin/firmware#163: We can not disable collectd and rrdtool
because there is no option in the ui to enable them again. Also the
luci_service should not be disabled even if the user does not enable
statistics during wizard setup because the luci_statistics ui needs the
service to be enabled to work.
