### PR TITLE
[olsrd-defaults] set SmartGatewayThreshold=50

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -52,6 +52,15 @@ update_luci_statistics_config() {
   /etc/init.d/luci_statistics enable
 }
 
+update_olsr_smart_gateway_threshold() {
+  # set SmartGatewayThreshold if not set
+  local threshold=$(uci get olsrd.olsrd.SmartGatewayThreshold)
+  if [ "x${threshold}" = x ]; then
+    log "Setting SmartGatewayThreshold to 50."
+    uci set olsrd.olsrd.SmartGatewayThreshold='50'
+  fi
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -60,6 +69,7 @@ migrate () {
     update_dhcp_lease_config
     update_wireless_ht20_config
     update_luci_statistics_config
+    update_olsr_smart_gateway_threshold
   fi
 
   # overwrite version with the new version

--- a/utils/freifunk-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
+++ b/utils/freifunk-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
@@ -52,6 +52,7 @@ uci set olsrd.$OLSRD.TcRedundancy=2
 uci set olsrd.$OLSRD.NatThreshold=0.75
 uci set olsrd.$OLSRD.LinkQualityAlgorithm=etx_ff
 uci set olsrd.$OLSRD.SmartGateway=yes
+uci set olsrd.$OLSRD.SmartGatewayThreshold=50
 uci set olsrd.$OLSRD.Pollrate=0.025
 uci set olsrd.$OLSRD.RtTable=111
 uci set olsrd.$OLSRD.RtTableDefault=112


### PR DESCRIPTION
Without SmartGatewayThreshold being set, the smart gateway endpoint is only
changed when it disappears. With SmartGatewayThreshold=50, it picks
another gateway if its ETX is 50% or less of the current gateway's ETX.