### PR TITLE
cosmetic changes

### DIFF
--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
@@ -9,7 +9,10 @@ f.reset = false
 css = f:field(DummyValue, "css", "")
 css.template = "freifunk/assistent/snippets/css"
 
-community = f:field(ListValue, "net", "Freifunk Community", "")
+generalinfo = f:field(DummyValue,"","")
+generalinfo.template = "freifunk/assistent/snippets/generalInfo"
+
+community = f:field(ListValue, "net", "Freifunk-Community", "")
 function community.cfgvalue(self, section)
   return uci:get("freifunk", "community", "name") or "berlin"
 end
@@ -22,19 +25,19 @@ for k,v in ipairs(communities) do
   community:value(n, name)
 end
 
-hostname = f:field(Value, "hostname", "Knoten Name", "")
+hostname = f:field(Value, "hostname", "Name dieses Freifunk-Knotens", "")
 hostname.datatype = "hostname"
 function hostname.cfgvalue(self, section)
   return uci:get_first("system", "system","hostname") or sys.hostname()
 end
 
-nickname = f:field(Value, "nickname", "Nickname","")
+nickname = f:field(Value, "nickname", "Dein Nickname","")
 nickname.datatype = "string"
 function nickname.cfgvalue(self, section)
   return uci:get("freifunk", "contact", "nickname")
 end
 
-realname = f:field(Value, "realname", "Realname","")
+realname = f:field(Value, "realname", "Dein Realname","")
 realname.datatype = "string"
 function realname.cfgvalue(self, section)
   return uci:get("freifunk", "contact", "name")
@@ -52,13 +55,13 @@ function location.cfgvalue(self, section)
   return uci:get_first("system", "system", "location") or uci:get("freifunk", "contact", "location")
 end
 
-lat = f:field(Value, "lat", "geographischer Breitengrad", "")
+lat = f:field(Value, "lat", "Geographischer Breitengrad", "")
 lat.datatype = "float"
 function lat.cfgvalue(self, section)
   return uci:get_first("system", "system","latitude")
 end
 
-lon = f:field(Value, "lon", "geograpischer Längengrad", "")
+lon = f:field(Value, "lon", "Geographischer Längengrad", "")
 lon.datatype = "float"
 function lon.cfgvalue(self, section)
   return uci:get_first("system", "system","longitude")
@@ -66,9 +69,6 @@ end
 
 map = f:field(DummyValue,"","")
 map.template = "freifunk/assistent/snippets/map"
-
-generalinfo = f:field(DummyValue,"","")
-generalinfo.template = "freifunk/assistent/snippets/generalInfo"
 
 main = f:field(DummyValue, "config", "", "")
 main.forcewrite = true

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -19,7 +19,7 @@ local community = "profile_"..uci:get("freifunk", "community", "name")
 local sharenet = uci:get("ffwizard", "settings", "sharenet")
 
 f = SimpleForm("ffwizard", "", "")
-f.submit = "Next"
+f.submit = "Save and reboot"
 f.cancel = "Back"
 f.reset = false
 
@@ -27,12 +27,15 @@ css = f:field(DummyValue, "css", "")
 css.template = "freifunk/assistent/snippets/css"
 
 -- ADHOC
+meshipinfo = f:field(DummyValue, "meshinfo", "")
+meshipinfo.template = "freifunk/assistent/snippets/meshipinfo"
+
 local wifi_tbl = {}
 uci:foreach("wireless", "wifi-device",
   function(section)
     local device = section[".name"]
     wifi_tbl[device] = {}
-    local meship = f:field(Value, "meship_" .. device, device:upper() .. " Mesh IP", "")
+    local meship = f:field(Value, "meship_" .. device, device:upper() .. " Mesh-IP", "")
     meship.rmempty = false
     meship.datatype = "ip4addr"
     function meship.cfgvalue(self, section)
@@ -45,21 +48,21 @@ uci:foreach("wireless", "wifi-device",
     wifi_tbl[device]["meship"] = meship
   end)
 
-meshipinfo = f:field(DummyValue, "meshinfo", "")
-meshipinfo.template = "freifunk/assistent/snippets/meshipinfo"
-
 -- VAP
 local community = "profile_"..uci:get("freifunk", "community", "name")
 local vap = uci:get_first(community, "community", "vap") or "1"
 if vap == "1" then
-  ssid = f:field(Value, "ssid", "Freifunk SSID", "")
+  ipinfo = f:field(DummyValue, "ipinfo", "")
+  ipinfo.template = "freifunk/assistent/snippets/ipinfo"
+
+  ssid = f:field(Value, "ssid", "Freifunk-SSID", "")
   ssid.rmempty = false
   function ssid.cfgvalue(self, section)
     return uci:get("ffwizard", "settings", "ssid")
       or uci:get(community, "profile", "ssid")
   end
 
-  dhcpmesh = f:field(Value, "dhcpmesh", "Addressraum", "")
+  dhcpmesh = f:field(Value, "dhcpmesh", "DHCP-Network", "")
   dhcpmesh.rmempty = false
   dhcpmesh.datatype = "ip4addr"
   function dhcpmesh.cfgvalue(self, section)
@@ -69,9 +72,6 @@ if vap == "1" then
     local x = ip.IPv4(value)
     return ( x and x:minhost() and x:prefix() < 32) and x:string() or ""
   end
-
-  ipinfo = f:field(DummyValue, "ipinfo", "")
-  ipinfo.template = "freifunk/assistent/snippets/ipinfo"
 end
 
 main = f:field(DummyValue, "netconfig", "", "")

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/decide.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/decide.htm
@@ -3,52 +3,52 @@
 <link href="/freifunk/assistent/assistent.css" rel="stylesheet" />
 
 <div class="section">
-  <h3>Freifunk Assistent</h3>
+  <h3>Freifunk-Assistent</h3>
 
   <div class="info alert-message">
     <p class="success">
 Die Standardeinstellungen sind geschafft. Als n&auml;chstes kommen
-die Einstellungen für das Freifunknetzwerk. Vorher solltest du dir
-mindestens eine <a target="blank"
-href="http://ip.berlin.freifunk.net/index.html">IP
-registrieren.</a> Ein Anleitung dafür findest du <a target="blank"
-href="hier">hier</a>.
+die Einstellungen für das Freifunk-Netzwerk. Halte die IPs bereit,
+die du &uuml;ber den Wizard von <a target="blank"
+href="http://config.berlin.freifunk.net/">config.berlin.freifunk.net</a>
+bekommen hast.
     </p>
   </div>
+
   <div class="tile">
     <div style="text-align: center; margin: 10px">
-      <a class="cbi-button cbi-button-save" href="<%=luci.dispatcher.build_url("/admin/freifunk/assistent/sharedInternet")%>">
-        Internet teilen
+      <a class="cbi-button cbi-button-save" href="<%=luci.dispatcher.build_url("admin/freifunk/assistent/optionalConfigs")%>">
+        Am Freifunk-Netz teilnehmen
       </a>
     </div>
     <div class="alert-message">
       <p class="info">
-Unterstütze die Community, indem du dein Internet frei gibst.
-Daf&uuml;r ist es nicht n&ouml;tig eine Sichtverindung zu anderen
-Freifunkroutern zu haben. Du ben&ouml;tigst allerdings einen
-VPN-Schl&uuml;ssel, den du auf der <a target="blank"
-href="http://lists.berlin.freifunk.net/cgi-bin/mailman/listinfo/berlin">Mailingliste</a>
-anfragen kannst. Informationen zu rechtlichen Grundlagen kannst du im <a target="blank" href="http://wiki.freifunk.net/F%26A_Rechtliches">Freifunk Wiki</a> nachlesen.
+        Erweitere das Freifunk-Netz. Du ben&ouml;tigst dazu eine
+        WLAN-Verbindung zu einem anderen Freifunk-Router.
+        Du kannst auf der <a target="blank"
+        href="http://berlin.freifunk.net/network/map/">Freifunk-Karte</a>
+        nachschauen, wer in deiner N&auml;he ist, und sie kontaktieren,
+        damit ihr die Verbindung optimal ausrichten k&ouml;nnt.
       </p>
     </div>
   </div>
+
   <div class="tile">
     <div style="text-align: center; margin: 10px">
-      <a class="cbi-button cbi-button-save" href="<%=luci.dispatcher.build_url("admin/freifunk/assistent/optionalConfigs")%>">
-        Freifunknetz bereitstellen
+      <a class="cbi-button cbi-button-save" href="<%=luci.dispatcher.build_url("/admin/freifunk/assistent/sharedInternet")%>">
+        Am Freifunk-Netz teilnehmen und Internet teilen
       </a>
-</div>
-<div class="alert-message">
-<p class="info">
-Erweitere das Freifunknetz. Du ben&ouml;tigst dazu eine
-Sichtverbindug zu einem anderen Freifunkrouter, damit sich dein
-Router verbinden kann. Du kannst auf der <a target="blank"
-href="http://berlin.freifunk.net/network/map/">Freifunkkarte</a>
-nachschauen, wer in deiner N&auml;he ist und sie kontaktieren,
-damit ihr die Verbindung optimal ausrichten k&ouml;nnt.
-</p>
-</div>
-</div>
+    </div>
+    <div class="alert-message">
+      <p class="info">
+        Unterstütze die Community, indem du dein Internet im Freifunk-Netzwerk freigibst.
+        Diese Option ist sowohl mit als auch ohne Verbindung zu anderen Freifunk-Routern sinnvoll.
+        Du ben&ouml;tigst einen VPN-Schl&uuml;ssel, den du auf der <a target="blank"
+        href="http://lists.berlin.freifunk.net/cgi-bin/mailman/listinfo/berlin">Mailingliste</a>
+        bekommen kannst. Weitere Informationen zum VPN gibt es im <a target="blank" href="http://wiki.freifunk.net/Vpn03">Freifunk-Wiki</a>.
+      </p>
+    </div>
+  </div>
 
 <div class="clear"></div>
 </div>

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/reboot.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/reboot.htm
@@ -8,14 +8,19 @@
 <div class="section">
   <div class="info alert-message">
     <p class="success">
-      Du hast alle Einstellungen geschafft und dein Router wird jetzt neu gestartet.
+      Du hast alle Einstellungen geschafft. Dein Router wird jetzt neu gestartet.
       Am besten, du machst dir kurz einen Kaffee oder einen Tee :D
       und sobald alle Lichter wieder blinken, bist du Freifunkerin!
     </p>
     <p>
-      Es gibt auch Services im Freifunknetz. Ein Liste kannst du dir
-      <a href="<%=luci.dispatcher.build_url("freifunk/services")%>">hier</a> oder im
-      Freifunk Hauptmenu unter Services ansehen,
+      Bitte beachte, dass der Router dann unter seiner neuen Freifunk-IP zu
+      erreichen ist. Von direkt per WLAN oder LAN angeschlossenen Rechnern
+      ist er auch unter dem Namen <a href="http://frei.funk/">frei.funk</a>
+      zu erreichen.
+    </p>
+    <p>
+      Es gibt auch Services im Freifunk-Netz. Ein Liste kannst du dir
+      im Freifunk-Hauptmenu unter "Services" ansehen,
       sobald dein Router neugestartet hat.
     </p>
   </div>

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/apinfo.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/apinfo.htm
@@ -2,7 +2,7 @@
   <p class="info">
     Neben dem offenen Freifunk-Access Point kannst du auch ein verschlüsselten
     privaten AP erstellen. Hier gehen deinen Daten ohne VPN-Verbindung direkt
-    ins Internet. Beachte das die Schlüssellänge mindenstens 8 Zeichen lang sein
+    ins Internet. Beachte, dass die Schlüssellänge mindestens 8 Zeichen lang sein
     muss.
   </p>
 </div>

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/generalInfo.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/generalInfo.htm
@@ -1,11 +1,15 @@
 <div class="alert-message">
   <p class="info">
-    Wenn du möchtest kannst du hier deine Kontaktdaten eingeben. So
-    k&ouml;nnen dich andere Freifunkerinnen finden und dich ansprechen,
-    falls sie Ihren Router mit deinem verbinden m&ouml;chten. Außerdem
-    wird der Standort deines Routers in der <a target="blank"
-    href="http://berlin.freifunk.net/network/map/">Freifunkkarte</a>
-    angezeigt. Falls du hier nichts angeben möchtest kannst du den
-    Punkt auch einfach &uuml;berspringen.
+    Wenn du möchtest, kannst du hier deine Kontaktdaten eingeben.
+    Die Kontaktdaten werden auf der Infoseite des Routers sowie auf
+    der <a target="blank"
+    href="http://berlin.freifunk.net/network/map/">Freifunk-Karte</a>
+    angezeigt. So k&ouml;nnen dich andere Freifunkerinnen finden und
+    dich ansprechen, falls sie Ihren Router mit deinem verbinden
+    m&ouml;chten.
+    <br/>Falls du hier nichts angeben möchtest, kannst du den
+    Punkt auch einfach &uuml;berspringen oder einzelne Felder leerlassen.
+    <br/>Den (eindeutigen) Namen dieses Freifunk-Knotens musst du
+    allerdings setzen.
   </p>
 </div>

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/ipinfo.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/ipinfo.htm
@@ -1,20 +1,20 @@
 <div class="alert-message">
+  <p>
+    Die SSID des Freifunk-WLAN-APs solltest du auf <em>berlin.freifunk.net</em> lassen,
+    sofern sich nicht in unmittelbarer N&auml;he ein weiterer Access Point
+    mit der gleichen SSID befindet. Auf diese Weise k&ouml;nnen sich
+    G&auml;ste z.B. mit ihrem Smartphone in der ganzen Gegend mit dem
+    Freifunk-Netzwerk verbinden, ohne spezielle Einstellungen f&uuml;r
+    jeden einzelnen Router vornehmen zu m&uuml;ssen.
+    <br/>Diese Einstellung bezieht sich auf den WLAN-AP, <em>nicht</em> das Adhoc-Netzwerk,
+    das f&uuml;r das Freifunk-Meshing benutzt wird.
+  </p>
   <p class="info">
-    Hier kannst du den Access Point f&uuml;r Clients deines
-    Freifunknetzwerkes konfigurieren.
-    Am besten benutzt du einen
-    <a target="blank" href="http://www.heise.de/netze/tools/netzwerkrechner/">Netzwerkrechner</a>
-    um die eine Netzwerkaddresse und das
-    CIDR-Suffix zu berechnen (Beispiel Schreibweise: 192.168.42.1/28).
+    Die DHCP-Einstellung regelt die Vergabe von IP-Adressen an Clients deines
+    Freifunk-Netzwerkes.
+    Die n&ouml;tige Angabe solltest du von <a target="_blank"
+    href="http://config.berlin.freifunk.net/">config.berlin.freifunk.net</a>
+    bekommen haben.
+    Dabei wird die CIDR-Schreibweise benutzt (Beispiel: 10.42.42.42/28).
   </p>
-  <p>
-    Die IPs werden an Clients vergeben, die sich per WLAN oder Kabel mit deinem Router verbinden.
-    Vergiss nicht alle IP-Adressen in der
-    <a href="http://ip.berlin.freifunk.net/index.html" target="blank">IP-Registrierung</a> einzutragen.
-  </p>
-  <p>
-    Achte beim Vergeben des Netzwerknamens (z.B.
-    meinname.freifunk.net) darauf, dass du unterschiedliche Namen
-    vergibst, falls du mehrere Router in deiner Umgebegung betreibst,
-    da ein Client mit seiner IP nicht die Access Points wechseln kann.</p>
 </div>

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/meshipinfo.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/meshipinfo.htm
@@ -1,10 +1,10 @@
 <div class="alert-message">
   <p class="info">
-    Falls du es noch nicht getan haben, dann
-    <a href="http://ip.berlin.freifunk.net/index.html">registriere</a>
-    dir jetzt eine bzw. zwei IPs, die du in die n&auml;chsten Felder eintr&auml;gst.
-    &Uuml;ber diese Adressse(n) verbindet sich dein Router mit anderen Routern
-    in deiner N&auml;he. Sp&auml;ter kannst du dir die Einstellungen unter Network
-    &gt; Interfaces und Network &gt; Wireleass anschauen.
+    Im Folgenden werden die IPs eingetragen, die du vom Wizard unter
+    <a target="_blank" href="http://config.berlin.freifunk.net/">config.berlin.freifunk.net</a>
+    bekommen hast.
+    &Uuml;ber diese Adresse(n) verbindet sich dein Router mit anderen Freifunk-Routern
+    in deiner N&auml;he. Sp&auml;ter kannst du dir die Einstellungen unter "Network
+    &gt; Interfaces und Network &gt; Wireless" anschauen.
   </p>
 </div>

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/shareBandwidth.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/shareBandwidth.htm
@@ -1,11 +1,11 @@
 <div class="alert-message">
   <p class="info">
     Hier kannst du einstellen, wie viel deiner Bandbreite Du teilen möchtest.
-    Wähle dazu deinen Internetanschluss aus und entscheide dich danach, wieviel Prozent davon von Freifunk
+    Wähle dazu deinen Internet-Anschlusstyp aus und entscheide dich danach, wieviel Prozent davon von Freifunk
     benutzt werden darf (Wer mehr Bandbreite hat, kann mehr teilen n_n). 
   </p>
   <p>
-    Alternativ dazu kannst du auch die Upload- und Downloadbandbreite genau einstellen.
-    Klicke dazu den Hacken bei "Benutzerdefinierte Einstellungen"
+    Alternativ dazu kannst du auch die Upload- und Download-Bandbreite genau einstellen.
+    W&auml;hle dazu "Benutzerdefinierte Einstellungen"
   </p>
 </div>

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/vpninfo.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/vpninfo.htm
@@ -1,8 +1,8 @@
 <div class="alert-message">
   <p class="info">
-    Falls du es noch nicht gemacht hast, solltest du dir jetzt einen VPN Schlüssel auf der
-    <a href="http://lists.berlin.freifunk.net/cgi-bin/mailman/listinfo/berlin" target="blank">Maillingste</a>
-    beantragen. Dann entpackst du die Datei, die dir zugeschickt wurde und lädst hier dein Zertifikat
+    Im Folgenden wird der VPN-Schl&uuml;ssel gebraucht, den du &uuml;ber die
+    <a href="http://lists.berlin.freifunk.net/cgi-bin/mailman/listinfo/berlin" target="blank">Mailingliste</a>
+    bekommen hast. Du entpackst die Datei, die dir zugeschickt wurde, und lädst hier dein Zertifikat
     und deinen Schlüssel hoch.
   </p>
 </div>

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/welcome.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/welcome.htm
@@ -1,11 +1,12 @@
 <div class="info alert-message">
   <p class="success">
-    Herzlichen Glückwunsch! Du hast deinen Router erfolgreich geflascht
-    und was du hier siehst ist die Freifunk-Firmware. Dieser Assistent
-    hilft dir beim Einrichten deines Routers. Wenn du keine Hilfe
+    Herzlichen Gl&uuml;ckwunsch!
+    <br/>Du hast deinen Router erfolgreich mit der Freifunk-Firmware ausgestattet.
+    Dieser Assistent hilft dir beim Einrichten deines Routers. Wenn du keine Hilfe
     brauchst, kannst du in der <a href="/admin">Administrationsoberfl&auml;che</a>
-    die Einstellungen auch alleine vornehmen. &Auml;ndere hier zunächst
-    dein Password. Sp&auml;ter findest du diese Option im Bereich
-    System &gt; Administration.
+    die Einstellungen auch alleine vornehmen.
+    <br/>&Auml;ndere hier zun&auml;chst dein Password. Bitte w&auml;hle ein
+    sicheres Passwort, da der Router nach au&szlig;en sichtbar ist.
+    Sp&auml;ter findest du diese Option im Bereich "System &gt; Administration".
   </p>
 </div>


### PR DESCRIPTION
Fixed typos. Removed outdated info (link to Heise netmask calculator - config.berlin does this). Moved some info boxes (the one on the contact form was located below the map and easily overlooked). Clarified data privacy. Switched wording to that used in the config.berlin info mail ("DHCP-Network"). Better descriptions on "decide" page.

No functional changes.