### PR TITLE
Exclude encrypted/wan interfaces in OWM info

### DIFF
--- a/utils/luci-app-owm/luasrc/owm.lua
+++ b/utils/luci-app-owm/luasrc/owm.lua
@@ -352,6 +352,10 @@ function get()
 			return
 		end
 		local name = vif['.name']
+		if ('wan' == name) or ('wan6' == name) then
+			-- fingers off wan as this will be the private internet uplink
+			return
+		end
 		local net = netm:get_network(name)
 		local device = net and net:get_interface()
 		root.interfaces[#root.interfaces+1] =  vif

--- a/utils/luci-app-owm/luasrc/owm.lua
+++ b/utils/luci-app-owm/luasrc/owm.lua
@@ -316,6 +316,13 @@ function get()
 			}) do
 				interfaces[#interfaces][f] = iwinfo[f]
 			end
+			if iwinfo['encryption'] then
+				if iwinfo['encryption']['enabled'] then
+					-- fingers off encrypted wifi interfaces, they are likely private
+					table.remove(interfaces)
+					return
+				end
+			end
 		end
 		assoclist_if = {}
 		for _, v in ipairs(assoclist) do


### PR DESCRIPTION
See https://github.com/freifunk-berlin/firmware/issues/206 .

This patch is intended to prevent owm.lua from pushing information about a) private encrypted wifi networks and b) the local WAN port configuration to the public.

Ultimatively, I think there should be a user-configurable whitelist instead of a blacklist, and some "show me what information gets published beforehand" functionality, but this is way too much effort with libremap coming.