### PR TITLE
[ffwizard-berlin] use move instead of copy after upload of key/cert

### DIFF
--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
@@ -107,8 +107,14 @@ function main.write(self, section, value)
     enabled='1'
   })
 
-  fs.copy("/lib/uci/upload/cbid.ffvpn.1.cert","/etc/openvpn/freifunk_client.crt")
-  fs.copy("/lib/uci/upload/cbid.ffvpn.1.key","/etc/openvpn/freifunk_client.key")
+  fs.move(
+    "/lib/uci/upload/cbid.ffvpn.1.cert",
+    "/etc/openvpn/freifunk_client.crt"
+  )
+  fs.move(
+    "/lib/uci/upload/cbid.ffvpn.1.key",
+    "/etc/openvpn/freifunk_client.key"
+  )
 
   uci:save("openvpn")
   uci:save("ffwizard")


### PR DESCRIPTION
Before this change we copied the key/cert files from the upload directory to the
/etc/openvpn directory. This results in a waste of disk space. If we use move
instead we do not keep redundant information on disk and save some space.

Thanks to Patrick Grimm for pointing this out.