### PR TITLE
[dhcp-defaults] add an ipv6 dns entry for frei.funk

### DIFF
--- a/utils/freifunk-berlin-dhcp-defaults/uci-defaults/freifunk-berlin-dhcp-defaults
+++ b/utils/freifunk-berlin-dhcp-defaults/uci-defaults/freifunk-berlin-dhcp-defaults
@@ -9,4 +9,10 @@ uci set dhcp.frei_funk=domain
 uci set dhcp.frei_funk.name=frei.funk
 uci set dhcp.frei_funk.ip=192.168.42.1
 
+# add dns entry frei.funk for ipv6
+router_ula=$(uci get network.globals.ula_prefix | sed -e 's/\/48/1/')
+uci set dhcp.frei_funk_ipv6=domain
+uci set dhcp.frei_funk_ipv6.name=frei.funk
+uci set dhcp.frei_funk_ipv6.ip=$router_ula
+
 uci commit dhcp


### PR DESCRIPTION
We use the ula prefix of the router to "calculate" the ip of the router.

Addresses: https://github.com/freifunk-berlin/firmware/issues/166