### PR TITLE
[freifunk-berlin-migration]: remove dependency on semver

### DIFF
--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -13,7 +13,6 @@ define Package/freifunk-berlin-migration
   CATEGORY:=freifunk-berlin
   TITLE:=Freifunk Berlin configuration migration script
   URL:=http://github.com/freifunk-berlin/packages_berlin
-  DEPENDS+= +semver
 endef
 
 define Package/freifunk-berlin-migration/description


### PR DESCRIPTION
freifunk-berlin-migration depends on 'semver', which doesn't exist
and is packages by itself (see files).