### PR TITLE
Fix collectd memory leak hotfix

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -56,7 +56,7 @@ update_collectd_memory_leak_hotfix() {
   # Hotfix for collectd memory leak: restart luci_statistics every 15 minutes
   # see https://github.com/freifunk-berlin/firmware/issues/217
   CRONTAB="/etc/crontabs/root"
-  CMD="/etc/init.d/luci_statistics reload"
+  CMD="/etc/init.d/luci_statistics restart"
   test -f $CRONTAB || touch $CRONTAB
   # remove broken fix of 0.1.0
   sed -i '/luci_statistics$/d' $CRONTAB
@@ -84,7 +84,9 @@ migrate () {
     update_olsr_smart_gateway_threshold
   fi
 
-  update_collectd_memory_leak_hotfix
+  if semverLT ${OLD_VERSION} "0.1.1"; then
+    update_collectd_memory_leak_hotfix
+  fi
 
   # overwrite version with the new version
   log "Setting new system version to ${VERSION}."

--- a/utils/freifunk-berlin-statistics-defaults/uci-defaults/freifunk-berlin-statistics-defaults
+++ b/utils/freifunk-berlin-statistics-defaults/uci-defaults/freifunk-berlin-statistics-defaults
@@ -73,10 +73,10 @@ uci set luci_statistics.collectd_network.enable=1
                                             
 uci commit luci_statistics                    
 
-# Hotfix for collectd memory leak: restart luci_statistics every 30 minutes
+# Hotfix for collectd memory leak: restart luci_statistics every 15 minutes
 # see https://github.com/freifunk-berlin/firmware/issues/217
 CRONTAB="/etc/crontabs/root"
-CMD="/etc/init.d/luci_statistics"
+CMD="/etc/init.d/luci_statistics reload"
 test -f $CRONTAB || touch $CRONTAB
-grep -q $CMD $CRONTAB || echo "0,30 * * * *	$CMD" >> $CRONTAB
+grep -q $CMD $CRONTAB || echo "0,15,30,45 * * * *	$CMD" >> $CRONTAB
 /etc/init.d/cron restart

--- a/utils/freifunk-berlin-statistics-defaults/uci-defaults/freifunk-berlin-statistics-defaults
+++ b/utils/freifunk-berlin-statistics-defaults/uci-defaults/freifunk-berlin-statistics-defaults
@@ -76,7 +76,7 @@ uci commit luci_statistics
 # Hotfix for collectd memory leak: restart luci_statistics every 15 minutes
 # see https://github.com/freifunk-berlin/firmware/issues/217
 CRONTAB="/etc/crontabs/root"
-CMD="/etc/init.d/luci_statistics reload"
+CMD="/etc/init.d/luci_statistics restart"
 test -f $CRONTAB || touch $CRONTAB
 grep -q $CMD $CRONTAB || echo "0,15,30,45 * * * *	$CMD" >> $CRONTAB
 /etc/init.d/cron restart


### PR DESCRIPTION
This is supposed to remove the noop line put into crontab by the 0.1.0 migration and insert a working command. Also, reloading every 15 minutes as at least some WR1043 seem not to last even 30 minutes. Do not merge yet, will do more testing.