### PR TITLE
[olsrd-defaults] set txtinfo port to 2006 (default)

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -76,6 +76,11 @@ update_olsr_smart_gateway_threshold() {
   fi
 }
 
+fix_olsrd_txtinfo_port() {
+  uci set $(uci show olsrd|grep olsrd_txtinfo|cut -d '=' -f 1|sed 's/library/port/')=2006
+  uci set $(uci show olsrd6|grep olsrd_txtinfo|cut -d '=' -f 1|sed 's/library/port/')=2006
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -89,6 +94,7 @@ migrate () {
 
   if semverLT ${OLD_VERSION} "0.1.1"; then
     update_collectd_memory_leak_hotfix
+    fix_olsrd_txtinfo_port
   fi
 
   # overwrite version with the new version

--- a/utils/freifunk-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
+++ b/utils/freifunk-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
@@ -11,7 +11,7 @@ EOF
 PLUGIN="$(uci add olsrd LoadPlugin)"
 uci set olsrd.$PLUGIN.accept=0.0.0.0
 uci set olsrd.$PLUGIN.library=olsrd_txtinfo.so.0.1
-uci set olsrd.$PLUGIN.port=2007
+uci set olsrd.$PLUGIN.port=2006
 
 # add arprefresh plugin
 PLUGIN="$(uci add olsrd LoadPlugin)"
@@ -87,7 +87,7 @@ EOF
 PLUGIN="$(uci add olsrd6 LoadPlugin)"
 uci set olsrd6.$PLUGIN.accept=0::
 uci set olsrd6.$PLUGIN.library=olsrd_txtinfo.so.0.1
-uci set olsrd6.$PLUGIN.port=2007
+uci set olsrd6.$PLUGIN.port=2006
 uci set olsrd6.$PLUGIN.ipv6only=true
 
 # add nameservice plugin


### PR DESCRIPTION
Both olsrd-txtinfo and collectd-olsrd default to port 2006; this changes our config to that default. http://www.olsr.org/?q=txtinfo_plugin https://collectd.org/wiki/index.php/Plugin:olsrd

This fixes https://github.com/freifunk-berlin/firmware/issues/218 . Do we need migration?