### PR TITLE
Changes to support routers with 4MB flash

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -98,6 +98,9 @@ migrate () {
   uci commit
 
   log "Migration done."
+
+  # delete any overlay config files duplicated from romfs by sysupgrade - saves JFFS2 space
+  cd /overlay/etc/config/ && for i in *; do [ -f "$i" ] && if cmp -s "$i" "/rom/etc/config/$i"; then rm -f "$i"; fi; done;
 }
 
 migrate

--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -16,8 +16,7 @@ define Package/luci-app-ffwizard-berlin
   SUBMENU:=3. Applications
   TITLE:=Freifunk Berlin configuration wizard
   URL:=http://berlin.freifunk.net
-  DEPENDS+= +luci-base +luci-mod-freifunk +luci-mod-admin-full \
-						+freifunk-policyrouting +freifunk-berlin-openvpn-files
+  DEPENDS+= +luci-base +luci-mod-admin-full +freifunk-policyrouting +freifunk-berlin-openvpn-files
 endef
 
 define Package/luci-app-ffwizard-berlin/description

--- a/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
@@ -7,9 +7,14 @@ local ipkg = require "luci.model.ipkg"
 local olsr = require "luci.tools.freifunk.assistent.olsr"
 local firewall = require "luci.tools.freifunk.assistent.firewall"
 
+local have_mod_freifunk = (ipkg.installed("luci-mod-freifunk") == true)
+
 module ("luci.controller.assistent.assistent", package.seeall)
 
 function index()
+  if not have_mod_freifunk then
+    entry({"admin", "freifunk"}, firstchild(), "Freifunk", 5).dependent=false
+  end
   entry({"admin", "freifunk", "assistent"}, call("prepare"), "Freifunkassistent", 1).dependent=false
   entry({"admin", "freifunk", "assistent", "changePassword"}, form("freifunk/assistent/changePassword"), "",1)
   entry({"admin", "freifunk", "assistent", "generalInfo"}, form("freifunk/assistent/generalInfo"), "", 1)

--- a/utils/luci-app-owm/Makefile
+++ b/utils/luci-app-owm/Makefile
@@ -74,6 +74,8 @@ endef
 define Package/luci-app-owm-cmd/install
 	$(INSTALL_DIR) $(1)/usr/sbin/
 	$(CP) files/owm.lua $(1)/usr/sbin/owm.lua
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(CP) files/owm-defaults $(1)/etc/uci-defaults/owm
 endef
 
 define Package/luci-app-owm-gui/install
@@ -81,8 +83,6 @@ define Package/luci-app-owm-gui/install
 	$(CP) $(PKG_BUILD_DIR)/luasrc/controller/owm.lua $(1)/usr/lib/lua/luci/controller/owm.lua
 	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/view
 	$(CP) $(PKG_BUILD_DIR)/luasrc/view/owm.htm $(1)/usr/lib/lua/luci/view/owm.htm
-	$(INSTALL_DIR) $(1)/etc/uci-defaults
-	$(CP) files/owm-defaults $(1)/etc/uci-defaults/owm
 endef
 
 define Package/luci-app-owm-ant/install

--- a/utils/luci-app-owm/Makefile
+++ b/utils/luci-app-owm/Makefile
@@ -26,7 +26,7 @@ endef
 
 define Package/luci-app-owm
   $(call Package/luci-app-owm/default)
-  DEPENDS:=+luci-lib-json +luci-mod-freifunk +olsrd-mod-jsoninfo +luci-lib-luaneightbl
+  DEPENDS:=+luci-lib-json +olsrd-mod-jsoninfo +luci-lib-luaneightbl
   TITLE:=Luci JSON Export for Open Wireless Map
 endef
 


### PR DESCRIPTION
1. The Assistent doesn't really depend on luci-mod-freifunk apart from patching into its menu entry. This removes the dependency: On small routers, luci-mod-freifunk can then be omitted.

2. sysupgrade copies all files in /etc/config to the overlay during the upgrade. Change migration to delete any duplicated files; this saves a dozen or so kb typically. Note: Patching sysupgrade itself would be better from a space-preserving perspective (as currently, the overlay has to hold the duplicate files briefly), but it would change the upgrate semantics from "keep config as-is" to "update any non-modified config files to ROM default".