### PR TITLE
[freifunk-berlin-openvpn-files] keep content of /etc/openvpn on sysup…

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -85,6 +85,10 @@ add_openvpn_mssfix() {
   uci set openvpn.ffvpn.mssfix=1300
 }
 
+fix_openvpn_ffvpn_up() {
+  uci set openvpn.ffvpn.up="/lib/freifunk/ffvpn-up.sh"
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -103,6 +107,10 @@ migrate () {
 
   if semverLT ${OLD_VERSION} "0.1.2"; then
     add_openvpn_mssfix
+  fi
+
+  if semverLT ${OLD_VERSION} "0.2.0"; then
+    fix_openvpn_ffvpn_up
   fi
 
   # overwrite version with the new version

--- a/utils/freifunk-berlin-openvpn-files/Makefile
+++ b/utils/freifunk-berlin-openvpn-files/Makefile
@@ -36,7 +36,9 @@ define Package/freifunk-berlin-openvpn-files/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(CP) ./uci-defaults/* $(1)/etc/uci-defaults
 	$(INSTALL_DIR) $(1)/etc/openvpn
-	$(CP) ./openvpn/* $(1)/etc/openvpn
+	$(CP) ./openvpn/freifunk-ca.crt $(1)/etc/openvpn
+	$(INSTALL_DIR) $(1)/lib/freifunk
+	$(CP) ./openvpn/ffvpn-up.sh $(1)/lib/freifunk
 endef
 
 $(eval $(call BuildPackage,freifunk-berlin-openvpn-files))

--- a/utils/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
+++ b/utils/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
@@ -26,7 +26,7 @@ uci set openvpn.ffvpn.ca="/etc/openvpn/freifunk-ca.crt"
 uci set openvpn.ffvpn.cert="/etc/openvpn/freifunk_client.crt"
 uci set openvpn.ffvpn.key="/etc/openvpn/freifunk_client.key"
 uci set openvpn.ffvpn.status="/var/log/openvpn-status-ffvpn.log"
-uci set openvpn.ffvpn.up="/etc/openvpn/ffvpn-up.sh"
+uci set openvpn.ffvpn.up="/lib/freifunk/ffvpn-up.sh"
 uci set openvpn.ffvpn.route_nopull=1
 uci commit openvpn
 

--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -48,8 +48,6 @@ define Package/luci-app-ffwizard-berlin/install
 	$(CP) ./htdocs/* $(1)/www
 	$(INSTALL_DIR) $(1)/etc
 	$(CP) ./root/etc/* $(1)/etc
-	$(INSTALL_DIR) $(1)/lib/upgrade/keep.d
-	$(CP) ./lib-upgrade/* $(1)/lib/upgrade/keep.d/
 endef
 
 $(eval $(call BuildPackage,luci-app-ffwizard-berlin))

--- a/utils/luci-app-ffwizard-berlin/lib-upgrade/openvpn
+++ b/utils/luci-app-ffwizard-berlin/lib-upgrade/openvpn
@@ -1,2 +1,0 @@
-/etc/openvpn/freifunk_client.crt
-/etc/openvpn/freifunk_client.key


### PR DESCRIPTION
…grade

This should fix https://github.com/freifunk-berlin/firmware/issues/238

We move the ffvpn-up.sh script to the /lib/freifunk directory. This way we
exclude the script from the backup of /etc/openvpn. Other communities already
use /lib/freifunk as directory for code so we use it instead of
/usr/lib/freifunk.

This is untested...