### PR TITLE
[freifunk-berlin-openvpn] [migration] set OpenVPN mssfix default to 1300

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -81,6 +81,10 @@ fix_olsrd_txtinfo_port() {
   uci set $(uci show olsrd6|grep olsrd_txtinfo|cut -d '=' -f 1|sed 's/library/port/')=2006
 }
 
+add_openvpn_mssfix() {
+  uci set openvpn.ffvpn.mssfix=1300
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -95,6 +99,10 @@ migrate () {
   if semverLT ${OLD_VERSION} "0.1.1"; then
     update_collectd_memory_leak_hotfix
     fix_olsrd_txtinfo_port
+  fi
+
+  if semverLT ${OLD_VERSION} "0.1.2"; then
+    add_openvpn_mssfix
   fi
 
   # overwrite version with the new version

--- a/utils/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
+++ b/utils/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
@@ -19,6 +19,7 @@ uci set openvpn.ffvpn.ns_cert_type=server
 uci set openvpn.ffvpn.comp_lzo="no"
 uci set openvpn.ffvpn.script_security=2
 uci set openvpn.ffvpn.cipher="none"
+uci set openvpn.ffvpn.mssfix=1300
 uci add_list openvpn.ffvpn.remote="vpn03.berlin.freifunk.net 1194 udp"
 uci add_list openvpn.ffvpn.remote="vpn03-backup.berlin.freifunk.net 1194 udp"
 uci set openvpn.ffvpn.ca="/etc/openvpn/freifunk-ca.crt"


### PR DESCRIPTION
This fixes problems with providers using DS-Lite and should reduce fragmentation on server side.

This adresses https://github.com/freifunk-berlin/firmware/issues/226 as well as parts of the OpenVPN server discussion.