### PR TITLE
[uhttpd-defaults]: do not force a redirect to https

### DIFF
--- a/utils/freifunk-berlin-uhttpd-defaults/uci-defaults/freifunk-berlin-uhttpd-defaults
+++ b/utils/freifunk-berlin-uhttpd-defaults/uci-defaults/freifunk-berlin-uhttpd-defaults
@@ -7,4 +7,6 @@ guard "uhttpd"
 # this should help us to avoid different certificates with same
 # commonname/issuer id
 uci set uhttpd.px5g.commonname="Freifunk Berlin - $(dd if=/dev/urandom bs=4 count=1 | hexdump -e '1/1 "%02x"')"
+# do not force redirect to https
+uci set uhttpd.main.redirect_https=0
 uci commit


### PR DESCRIPTION
The assumption is that the forced redirect is irritating for the average users
because the self signed certificate is not trusted by the browser. The user has
to add the certificate by hand. We assume that is to much for the average user.