### PR TITLE
[ff-berlin-statistics-defaults]: change ping host for collectd

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -105,6 +105,11 @@ add_firewall_rule_vpn03c() {
   fi
 }
 
+update_collectd_ping() {
+ uci set luci_statistics.collectd_ping.Interval=10
+ uci set luci_statistics.collectd_ping.Hosts=ping.berlin.freifunk.net
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -128,6 +133,7 @@ migrate () {
   if semverLT ${OLD_VERSION} "0.2.0"; then
     fix_openvpn_ffvpn_up
     add_firewall_rule_vpn03c
+    update_collectd_ping
   fi
 
   # overwrite version with the new version

--- a/utils/freifunk-berlin-statistics-defaults/uci-defaults/freifunk-berlin-statistics-defaults
+++ b/utils/freifunk-berlin-statistics-defaults/uci-defaults/freifunk-berlin-statistics-defaults
@@ -34,7 +34,7 @@ uci set luci_statistics.collectd.ReadThreads=2
 uci set luci_statistics.collectd_ping=statistics
 uci set luci_statistics.collectd_ping.enable=$HAVE_PLENTY_RAM
 uci set luci_statistics.collectd_ping.TTL=127
-uci set luci_statistics.collectd_ping.Interval=30
+uci set luci_statistics.collectd_ping.Interval=10
 uci set luci_statistics.collectd_ping.Hosts=ping.berlin.freifunk.net
 
 # mod interface

--- a/utils/freifunk-berlin-statistics-defaults/uci-defaults/freifunk-berlin-statistics-defaults
+++ b/utils/freifunk-berlin-statistics-defaults/uci-defaults/freifunk-berlin-statistics-defaults
@@ -35,7 +35,7 @@ uci set luci_statistics.collectd_ping=statistics
 uci set luci_statistics.collectd_ping.enable=$HAVE_PLENTY_RAM
 uci set luci_statistics.collectd_ping.TTL=127
 uci set luci_statistics.collectd_ping.Interval=30
-uci set luci_statistics.collectd_ping.Hosts=monitor.berlin.freifunk.net
+uci set luci_statistics.collectd_ping.Hosts=ping.berlin.freifunk.net
 
 # mod interface
 uci set luci_statistics.collectd_interface=statistics


### PR DESCRIPTION
We change the dns entry for the ping plugin to a more flexible dns entry. At the
moment the entry only points to a ipv4 address.

Addresses: https://github.com/freifunk-berlin/firmware/issues/253

TODO:

* [x] create a migration step