### PR TITLE
[ffwizard] [migration] use ffvpn for QoS rather than wan

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -105,6 +105,13 @@ add_firewall_rule_vpn03c() {
   fi
 }
 
+fix_qos_interface() {
+  for rule in `uci show qos|grep qos.wan`; do
+    uci set ${rule/wan/ffvpn}
+  done
+  uci delete qos.wan
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -128,6 +135,7 @@ migrate () {
   if semverLT ${OLD_VERSION} "0.2.0"; then
     fix_openvpn_ffvpn_up
     add_firewall_rule_vpn03c
+    fix_qos_interface
   fi
 
   # overwrite version with the new version

--- a/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/ffwizard.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/ffwizard.lua
@@ -41,7 +41,8 @@ function configureQOS()
 
     uci:delete("qos","wan")
     uci:delete("qos","lan")
-    uci:section("qos", 'interface', "wan", {
+    uci:delete("qos","ffvpn")
+    uci:section("qos", 'interface', "ffvpn", {
       enabled = "1",
       classgroup = "Default",
       upload = up,


### PR DESCRIPTION
this fixes https://github.com/freifunk-berlin/firmware/issues/257