### PR TITLE
[luci-app-ffwizard-berlin] Remove existing certificate files

### DIFF
--- a/utils/luci-app-ffwizard-berlin/htdocs/freifunk/assistent/assistent.css
+++ b/utils/luci-app-ffwizard-berlin/htdocs/freifunk/assistent/assistent.css
@@ -17,3 +17,7 @@
 #map {
   margin-top:20px;
 }
+
+.cbi-input-image {
+	width: 55px
+}

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
@@ -66,21 +66,19 @@ function main.write(self, section, value)
     enabled='1'
   })
 
-  fs.remove(
-    "/etc/openvpn/freifunk_client.crt"
-  )
-  fs.remove(
-    "/etc/openvpn/freifunk_client.key"
-  )
+  if fs.access("/lib/uci/upload/cbid.ffvpn.1.cert") and fs.access("/lib/uci/upload/cbid.ffvpn.1.key") then
+    fs.remove("/etc/openvpn/freifunk_client.crt")
+    fs.remove("/etc/openvpn/freifunk_client.key")
 
-  fs.move(
-    "/lib/uci/upload/cbid.ffvpn.1.cert",
-    "/etc/openvpn/freifunk_client.crt"
-  )
-  fs.move(
-    "/lib/uci/upload/cbid.ffvpn.1.key",
-    "/etc/openvpn/freifunk_client.key"
-  )
+    fs.move(
+      "/lib/uci/upload/cbid.ffvpn.1.cert",
+      "/etc/openvpn/freifunk_client.crt"
+    )
+    fs.move(
+      "/lib/uci/upload/cbid.ffvpn.1.key",
+      "/etc/openvpn/freifunk_client.key"
+    )
+  end
 
   uci:save("openvpn")
   uci:save("ffwizard")

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
@@ -66,6 +66,13 @@ function main.write(self, section, value)
     enabled='1'
   })
 
+  fs.remove(
+    "/etc/openvpn/freifunk_client.crt"
+  )
+  fs.remove(
+    "/etc/openvpn/freifunk_client.key"
+  )
+
   fs.move(
     "/lib/uci/upload/cbid.ffvpn.1.cert",
     "/etc/openvpn/freifunk_client.crt"

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/vpncertreupload.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/vpncertreupload.htm
@@ -1,5 +1,0 @@
-<div style="text-align: center; margin: 10px">
-  <a class="cbi-button cbi-button-save" href="<%=luci.dispatcher.build_url("admin/freifunk/assistent/sharedInternet")%>?reupload=1">
-    VPN-Schl&uuml;ssel erneut hochladen
-  </a>
-</div>


### PR DESCRIPTION
Allows to use the wizard to change certificates. Before this failed due to already existing files in the destination of the following move.

This fixes the issue https://github.com/freifunk-berlin/firmware/issues/287 and is based on the patch provided there. 