### PR TITLE
update links to new VPN-request webtool

### DIFF
--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/decide.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/decide.htm
@@ -43,7 +43,7 @@ bekommen hast.
         Unterstütze die Community, indem du dein Internet im Freifunk-Netzwerk freigibst.
         Diese Option ist sowohl mit als auch ohne Verbindung zu anderen Freifunk-Routern sinnvoll.
         Du ben&ouml;tigst einen VPN-Schl&uuml;ssel, den du auf der <a target="blank"
-        href="http://ca.berlin.freifunk.net">VPN-Zertifikatsseite</a>
+        href="https://ca.berlin.freifunk.net">VPN-Zertifikatsseite</a>
         beantragen kannst. Weitere Informationen zum VPN gibt es im <a target="blank" href="http://wiki.freifunk.net/Vpn03">Freifunk-Wiki</a>.
       </p>
     </div>

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/decide.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/decide.htm
@@ -9,7 +9,7 @@
     <p class="success">
 Als n&auml;chstes kommen die Einstellungen für das Freifunk-Netzwerk.
 Halte die IPs bereit, die du &uuml;ber den Wizard von <a target="blank"
-href="http://config.berlin.freifunk.net/">config.berlin.freifunk.net</a>
+href="https://config.berlin.freifunk.net/">config.berlin.freifunk.net</a>
 bekommen hast.
     </p>
   </div>

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/decide.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/decide.htm
@@ -43,8 +43,8 @@ bekommen hast.
         Unterstütze die Community, indem du dein Internet im Freifunk-Netzwerk freigibst.
         Diese Option ist sowohl mit als auch ohne Verbindung zu anderen Freifunk-Routern sinnvoll.
         Du ben&ouml;tigst einen VPN-Schl&uuml;ssel, den du auf der <a target="blank"
-        href="http://lists.berlin.freifunk.net/cgi-bin/mailman/listinfo/berlin">Mailingliste</a>
-        bekommen kannst. Weitere Informationen zum VPN gibt es im <a target="blank" href="http://wiki.freifunk.net/Vpn03">Freifunk-Wiki</a>.
+        href="http://ca.berlin.freifunk.net">VPN-Zertifikatsseite</a>
+        beantragen kannst. Weitere Informationen zum VPN gibt es im <a target="blank" href="http://wiki.freifunk.net/Vpn03">Freifunk-Wiki</a>.
       </p>
     </div>
   </div>

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/ipinfo.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/ipinfo.htm
@@ -13,7 +13,7 @@
     Die DHCP-Einstellung regelt die Vergabe von IP-Adressen an Clients deines
     Freifunk-Netzwerkes.
     Die n&ouml;tige Angabe solltest du von <a target="_blank"
-    href="http://config.berlin.freifunk.net/">config.berlin.freifunk.net</a>
+    href="https://config.berlin.freifunk.net/">config.berlin.freifunk.net</a>
     bekommen haben.
     Dabei wird die CIDR-Schreibweise benutzt (Beispiel: 10.42.42.42/28).
   </p>

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/meshipinfo.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/meshipinfo.htm
@@ -1,7 +1,7 @@
 <div class="alert-message">
   <p class="info">
     Im Folgenden werden die IPs eingetragen, die du vom Wizard unter
-    <a target="_blank" href="http://config.berlin.freifunk.net/">config.berlin.freifunk.net</a>
+    <a target="_blank" href="https://config.berlin.freifunk.net/">config.berlin.freifunk.net</a>
     bekommen hast.
     &Uuml;ber diese Adresse(n) verbindet sich dein Router mit anderen Freifunk-Routern
     in deiner N&auml;he. Sp&auml;ter kannst du dir die Einstellungen unter "Network

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/vpninfo.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/vpninfo.htm
@@ -1,8 +1,8 @@
 <div class="alert-message">
   <p class="info">
     Im Folgenden wird der VPN-Schl&uuml;ssel gebraucht, den du &uuml;ber die
-    <a href="http://lists.berlin.freifunk.net/cgi-bin/mailman/listinfo/berlin" target="blank">Mailingliste</a>
-    bekommen hast. Du entpackst die Datei, die dir zugeschickt wurde, und lädst hier dein Zertifikat
+    <a href="http://ca.berlin.freifunk.net" target="blank">VPN-Zertifikatsseite</a>
+    beantragt hast. Du entpackst die Datei, die dir zugeschickt wurde, und lädst hier dein Zertifikat
     und deinen Schlüssel hoch.
   </p>
 </div>

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/vpninfo.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/vpninfo.htm
@@ -1,7 +1,7 @@
 <div class="alert-message">
   <p class="info">
     Im Folgenden wird der VPN-Schl&uuml;ssel gebraucht, den du &uuml;ber die
-    <a href="http://ca.berlin.freifunk.net" target="blank">VPN-Zertifikatsseite</a>
+    <a href="https://ca.berlin.freifunk.net" target="blank">VPN-Zertifikatsseite</a>
     beantragt hast. Du entpackst die Datei, die dir zugeschickt wurde, und lädst hier dein Zertifikat
     und deinen Schlüssel hoch.
   </p>


### PR DESCRIPTION
remove all reverence to ask for VPN-key on the mailinglist and reference the new ca.berlin.freifunk.net page