### PR TITLE
Start OpenVPN via hotplug script

### DIFF
--- a/utils/freifunk-berlin-firewall-defaults/uci-defaults/freifunk-berlin-firewall-defaults
+++ b/utils/freifunk-berlin-firewall-defaults/uci-defaults/freifunk-berlin-firewall-defaults
@@ -81,6 +81,7 @@ uci set firewall.zone_freifunk.forward=REJECT
 uci set firewall.zone_freifunk.name=freifunk
 uci set firewall.zone_freifunk.output=ACCEPT
 uci set firewall.zone_freifunk.network=tunl0
+uci set firewall.zone_freifunk.device=tnl_+
 
 FORWARDING="$(uci add firewall forwarding)"
 uci set firewall.$FORWARDING.dest=freifunk
@@ -123,9 +124,3 @@ uci set firewall.$FORWARDING.dest=freifunk
 uci set firewall.$FORWARDING.src=wan
 
 uci commit
-
-# SmartGateway - set client rules (no nat, just forward)
-# see http://wiki.freifunk.net/OLSR/SmartGateway#.22Client.22
-FORWARD_TNL="iptables -I FORWARD -o tnl_+ -j ACCEPT"
-grep -q "$FORWARD_TNL" /etc/firewall.user || echo $FORWARD_TNL >> /etc/firewall.user
-MASQUERADE_TNL="iptables -t nat -I POSTROUTING -o tnl_+ -j MASQUERADE"

--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -130,24 +130,15 @@ add_openvpn_mssfix() {
   uci set openvpn.ffvpn.mssfix=1300
 }
 
-fix_openvpn_ffvpn_up() {
+openvpn_ffvpn_hotplug() {
   uci set openvpn.ffvpn.up="/lib/freifunk/ffvpn-up.sh"
-}
-
-add_firewall_rule_vpn03c() {
-  # add a firewall rule for vpn03c
-  # do not create tunnels via the mesh network
-  local rule=$(grep Reject-VPN-over-ff-3 /etc/config/firewall)
-  if [ "x${rule}" = x ]; then
-    rule="$(uci add firewall rule)"
-    uci set firewall.${rule}.proto=udp
-    uci set firewall.${rule}.name=Reject-VPN-over-ff-3
-    uci set firewall.${rule}.dest=freifunk
-    uci set firewall.${rule}.dest_ip=77.87.49.68
-    uci set firewall.${rule}.dest_port=1194
-    uci set firewall.${rule}.target=REJECT
-    uci set firewall.${rule}.family=ipv4
-  fi
+  uci set openvpn.ffvpn.nobind=0
+  /etc/init.d/openvpn disable
+  for entry in `uci show firewall|grep Reject-VPN-over-ff|cut -d '=' -f 1`; do
+    uci delete ${entry%.name}
+  done
+  uci delete freifunk-watchdog
+  crontab -l | grep -v "/usr/sbin/ffwatchd" | crontab -
 }
 
 update_collectd_ping() {
@@ -188,11 +179,10 @@ migrate () {
   fi
 
   if semverLT ${OLD_VERSION} "0.2.0"; then
-    fix_openvpn_ffvpn_up
-    add_firewall_rule_vpn03c
     update_collectd_ping
     fix_qos_interface
     remove_dhcp_interface_lan
+    openvpn_ffvpn_hotplug
   fi
 
   # overwrite version with the new version

--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -153,6 +153,11 @@ fix_qos_interface() {
   uci delete qos.wan
 }
 
+sgw_rules_to_fw3() {
+  uci set firewall.zone_freifunk.device=tnl_+
+  sed -i '/iptables -I FORWARD -o tnl_+ -j ACCEPT$/d' /etc/firewall.user
+}
+
 remove_dhcp_interface_lan() {
   uci -q delete dhcp.lan
   uci commit dhcp
@@ -183,6 +188,7 @@ migrate () {
     fix_qos_interface
     remove_dhcp_interface_lan
     openvpn_ffvpn_hotplug
+    sgw_rules_to_fw3
   fi
 
   # overwrite version with the new version

--- a/utils/freifunk-berlin-openvpn-files/Makefile
+++ b/utils/freifunk-berlin-openvpn-files/Makefile
@@ -39,6 +39,8 @@ define Package/freifunk-berlin-openvpn-files/install
 	$(CP) ./openvpn/freifunk-ca.crt $(1)/etc/openvpn
 	$(INSTALL_DIR) $(1)/lib/freifunk
 	$(CP) ./openvpn/ffvpn-up.sh $(1)/lib/freifunk
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
+	$(CP) ./openvpn/60-ffopenvpn $(1)/etc/hotplug.d/iface
 endef
 
 $(eval $(call BuildPackage,freifunk-berlin-openvpn-files))

--- a/utils/freifunk-berlin-openvpn-files/openvpn/60-ffopenvpn
+++ b/utils/freifunk-berlin-openvpn-files/openvpn/60-ffopenvpn
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+. /lib/functions.sh
+. /lib/functions/network.sh
+
+config_load ffwizard
+local sharenet
+config_get sharenet settings sharenet
+
+[ "$sharenet" = 1 ] || exit
+
+[ "$INTERFACE" = ffvpn ] && [ "$ACTION" = ifup ] && logger -t ff-userlog "OpenVPN connection has been established"
+[ "$INTERFACE" = ffvpn ] && [ "$ACTION" = ifdown ] && logger -t ff-userlog "OpenVPN connection went down"
+
+[ "$INTERFACE" = wan ] || exit
+
+config_load openvpn
+local uci_vpn_enabled
+config_get uci_vpn_enabled ffvpn enabled
+
+if [ "$ACTION" = ifup ]; then
+  logger -t ff-userlog "WAN interface is up"
+  if [ "$uci_vpn_enabled" = 1 ]; then
+    logger -t ff-vpn-hotplug "Starting OpenVPN on WAN interface"
+    # Make sure OpenVPN connects only through WAN: set "local" option with WAN IP
+    local wanip
+    network_get_ipaddr wanip "wan"
+    uci set openvpn.ffvpn.local=$wanip
+    uci commit openvpn
+    /etc/init.d/openvpn start
+    exit
+  fi
+fi
+
+if [ "$ACTION" = ifdown ]; then
+  logger -t ff-userlog "WAN interface went down"
+    if [ "$uci_vpn_enabled" = 1 ]; then
+      logger -t ff-vpn-hotplug "Stopping OpenVPN"
+      /etc/init.d/openvpn stop
+    exit
+  fi
+fi
+

--- a/utils/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
+++ b/utils/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
@@ -33,34 +33,3 @@ uci set network.ffvpn=interface
 uci set network.ffvpn.ifname=ffvpn
 uci set network.ffvpn.proto=none
 uci commit network
-
-# prevent connection to vpn03 via freifunk network
-# please add here all IPs that vpn03.berlin.freifunk.net resolves to
-RULE="$(uci add firewall rule)"
-uci set firewall.${RULE}.proto=udp
-uci set firewall.${RULE}.name=Reject-VPN-over-ff-1
-uci set firewall.${RULE}.dest=freifunk
-uci set firewall.${RULE}.dest_ip=77.87.48.10
-uci set firewall.${RULE}.dest_port=1194
-uci set firewall.${RULE}.target=REJECT
-uci set firewall.${RULE}.family=ipv4
-
-RULE="$(uci add firewall rule)"
-uci set firewall.${RULE}.proto=udp
-uci set firewall.${RULE}.name=Reject-VPN-over-ff-2
-uci set firewall.${RULE}.dest=freifunk
-uci set firewall.${RULE}.dest_ip=77.87.49.66
-uci set firewall.${RULE}.dest_port=1194
-uci set firewall.${RULE}.target=REJECT
-uci set firewall.${RULE}.family=ipv4
-
-RULE="$(uci add firewall rule)"
-uci set firewall.${RULE}.proto=udp
-uci set firewall.${RULE}.name=Reject-VPN-over-ff-3
-uci set firewall.${RULE}.dest=freifunk
-uci set firewall.${RULE}.dest_ip=77.87.49.68
-uci set firewall.${RULE}.dest_port=1194
-uci set firewall.${RULE}.target=REJECT
-uci set firewall.${RULE}.family=ipv4
-
-uci commit firewall

--- a/utils/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
+++ b/utils/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
@@ -9,7 +9,6 @@ uci delete openvpn.sample_client
 uci set openvpn.ffvpn=openvpn
 uci set openvpn.ffvpn.enabled=0
 uci set openvpn.ffvpn.client=1
-uci set openvpn.ffvpn.nobind=1
 uci set openvpn.ffvpn.proto=udp
 uci set openvpn.ffvpn.dev=ffvpn
 uci set openvpn.ffvpn.dev_type=tun

--- a/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
@@ -92,7 +92,6 @@ function commit()
   olsr.configureOLSR()
   olsr.configureOLSRPlugins()
 
-  tools.configureWatchdog()
   tools.configureQOS()
 
   uci:commit("dhcp")
@@ -104,11 +103,12 @@ function commit()
   uci:commit("freifunk")
   uci:commit("wireless")
   uci:commit("network")
-  uci:commit("freifunk-watchdog")
   uci:commit("qos")
 
   sys.init.enable("olsrd")
   sys.init.enable("olsrd6")
+  -- openvpn gets started by wan hotplug script
+  sys.init.disable("openvpn")
 
   if (sharenet == "1") then
     sys.init.enable("qos")
@@ -141,7 +141,6 @@ function reset()
   uci:revert("freifunk")
   uci:revert("wireless")
   uci:revert("network")
-  uci:revert("freifunk-watchdog")
   uci:revert("qos")
 
   if ipkg.installed("luci-app-statistics") == True then

--- a/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/ffwizard.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/ffwizard.lua
@@ -22,17 +22,6 @@ local sharenet = uci:get("ffwizard", "settings", "sharenet")
 
 module ("luci.tools.freifunk.assistent.ffwizard", package.seeall)
 
-function configureWatchdog()
-	if (sharenet =="1") then
-		uci:section("freifunk-watchdog", "process", nil, {
-			process="openvpn",
-			initscript="/etc/init.d/openvpn"
-		})
-		uci:save("freifunk-watchdog")
-	end
-end
-
-
 function configureQOS()
   if sharenet == "1" then
     -- values have to be in kilobits/second


### PR DESCRIPTION
This moves starting OpenVPN to a hotplug script.

Discussion: https://github.com/freifunk-berlin/firmware/issues/272

This removes the "block VPN03 IPs in firewall to prevent the always-running OpenVPN process from connecting to VPN03 via mesh" hack.

It directly launches OpenVPN in the ifup script but leaves the user the option to use UCI OpenVPN settings. This is probably unnecessary - nobody is really using UCI to configure OpenVPN - and the upcoming rewritten wizard will support standard OpenVPN config files as they are supplied by commercial OpenVPN providers.

Also, a hidden dependency on iptables is removed; fw3 does handling of the tnl interfaces here.

Probably procd should be used instead of directly launching OpenVPN. Someone else up to implementing this?