### PR TITLE
openvpn-script "ffvpn-up.sh" changed in #a63a603 to /lib/freifunk/

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -107,6 +107,7 @@ fix_qos_interface() {
     uci set ${rule/wan/ffvpn}
   done
   uci delete qos.wan
+}
 
 sgw_rules_to_fw3() {
   uci set firewall.zone_freifunk.device=tnl_+

--- a/utils/freifunk-berlin-openvpn-files/openvpn/60-ffopenvpn
+++ b/utils/freifunk-berlin-openvpn-files/openvpn/60-ffopenvpn
@@ -38,7 +38,7 @@ if [ "$ACTION" = ifup ]; then
           --cert /etc/openvpn/freifunk_client.crt \
           --key /etc/openvpn/freifunk_client.key \
           --status /var/log/openvpn-status-ffvpn.log \
-          --up /etc/openvpn/ffvpn-up.sh \
+          --up /lib/freifunk/ffvpn-up.sh \
           --writepid /var/run/ff-openvpn.pid \
           --local $wanip &
 fi


### PR DESCRIPTION
- fixes syntax error in migration-script
- stops openvpn to crash on startup with "file not found"