### PR TITLE
[ffwizard] do not enable VPN03, as this is controlled by hotplug-script

### DIFF
--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
@@ -63,7 +63,7 @@ function main.write(self, section, value)
 
   uci:section("openvpn", "openvpn", "ffvpn", {
     --persist_tun='0',
-    enabled='1'
+    enabled='0'
   })
 
   fs.move(


### PR DESCRIPTION
In aacb343 setting the default-config of VPN03 was removed from
"freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn" and is
incomplete by default. The OpenVPN-deamon wil be controlled by hotplugd, but
only when not enabled in UCI.
So don't enable it by default.