### PR TITLE
Fix/correcting owm deps

### DIFF
--- a/utils/luci-app-owm/Makefile
+++ b/utils/luci-app-owm/Makefile
@@ -63,7 +63,7 @@ define Build/Compile
 	$(MAKE) -C $(PKG_BUILD_DIR)/luasrc
 endef
 
-define Package/luci-app-owm-gui/postinst
+define Package/luci-app-owm-cmd/postinst
 #!/bin/sh
 if [ -z $${IPKG_INSTROOT} ] ; then
 	( . /etc/uci-defaults/owm ) && rm -f /etc/uci-defaults/owm
@@ -101,3 +101,4 @@ $(eval $(call BuildPackage,luci-app-owm))
 $(eval $(call BuildPackage,luci-app-owm-cmd))
 $(eval $(call BuildPackage,luci-app-owm-gui))
 $(eval $(call BuildPackage,luci-app-owm-ant))
+

--- a/utils/luci-app-owm/Makefile
+++ b/utils/luci-app-owm/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-owm
-PKG_RELEASE:=0.4.10
+PKG_RELEASE:=0.4.11
 
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)

--- a/utils/luci-app-owm/files/owm-defaults
+++ b/utils/luci-app-owm/files/owm-defaults
@@ -2,6 +2,4 @@
 test -f /etc/crontabs/root || touch /etc/crontabs/root
 SEED="$( dd if=/dev/urandom bs=2 count=1 2>&- | hexdump | if read line; then echo 0x${line#* }; fi )"
 MIN="$(( $SEED % 59 ))"
-crontab -l | grep -q "owm.lua" || echo "$MIN * * * *	test -e /usr/sbin/owm.lua && /usr/sbin/owm.lua" >> /etc/crontabs/root
-/etc/init.d/cron restart
-
+crontab -l | grep -q "owm.lua" || crontab -l | { cat; echo "$MIN * * * *	test -e /usr/sbin/owm.lua && /usr/sbin/owm.lua"; } | crontab -

--- a/utils/luci-app-owm/files/owm-defaults
+++ b/utils/luci-app-owm/files/owm-defaults
@@ -2,6 +2,6 @@
 test -f /etc/crontabs/root || touch /etc/crontabs/root
 SEED="$( dd if=/dev/urandom bs=2 count=1 2>&- | hexdump | if read line; then echo 0x${line#* }; fi )"
 MIN="$(( $SEED % 59 ))"
-grep -q "owm.lua" /etc/crontabs/root || echo "$MIN * * * *	/usr/sbin/owm.lua" >> /etc/crontabs/root
+crontab -l | grep -q "owm.lua" || echo "$MIN * * * *	test -e /usr/sbin/owm.lua && /usr/sbin/owm.lua" >> /etc/crontabs/root
 /etc/init.d/cron restart
 


### PR DESCRIPTION
- this puts the "owm-defaults" file for setting up the cron-job to the owm-cmd package, where the called binary is inside
- add some checks for binary in cron-job
- rely on "crontab"-util to modify crontab (not "crond restart" required and saves some bytes on flash
  - tested this for empty and existing crontabs
