### PR TITLE
do not update OWM without latitude/longitude defined

### DIFF
--- a/utils/luci-app-owm/Makefile
+++ b/utils/luci-app-owm/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-owm
-PKG_RELEASE:=0.4.10
+PKG_RELEASE:=0.4.11
 
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)

--- a/utils/luci-app-owm/files/owm.lua
+++ b/utils/luci-app-owm/files/owm.lua
@@ -53,7 +53,7 @@ function unlock()
 	os.execute("rm -f "..lockfile)
 end
 
--- a location for the node is required to run
+-- location for the node is required
 if next(owm.get_position())==nil then
 	if arg[1]=="--dry-run" then
 		print("no latitude/longitude specified for node.")
@@ -64,7 +64,7 @@ end
 
 lock()
 
-uci:foreach("system", "system", function(s) --owm
+uci:foreach("system", "system", function(s)
 	hostname = s.hostname
 end)
 

--- a/utils/luci-app-owm/files/owm.lua
+++ b/utils/luci-app-owm/files/owm.lua
@@ -54,7 +54,7 @@ function unlock()
 end
 
 -- location for the node is required
-if next(owm.get_position())==nil then
+if owm.get_position()==nil then
 	if arg[1]=="--dry-run" then
 		print("no latitude/longitude specified for node.")
 	end

--- a/utils/luci-app-owm/files/owm.lua
+++ b/utils/luci-app-owm/files/owm.lua
@@ -53,6 +53,15 @@ function unlock()
 	os.execute("rm -f "..lockfile)
 end
 
+-- a location for the node is required to run
+if next(owm.get_position())==nil then
+	if arg[1]=="--dry-run" then
+		print("no latitude/longitude specified for node.")
+	end
+	unlock()
+	return
+end
+
 lock()
 
 uci:foreach("system", "system", function(s) --owm

--- a/utils/luci-app-owm/luasrc/owm.lua
+++ b/utils/luci-app-owm/luasrc/owm.lua
@@ -211,7 +211,11 @@ function get_position()
 		position['latitude'] = tonumber(s.latitude)
 		position['longitude'] = tonumber(s.longitude)
 	end)
-	return position
+	if (position['latitude'] and  position['longitude']) then
+		return position
+	else
+		return nil
+	end
 end
 
 function get()

--- a/utils/luci-app-owm/luasrc/owm.lua
+++ b/utils/luci-app-owm/luasrc/owm.lua
@@ -207,9 +207,9 @@ end
 
 function get_position()
 	local position = {}
-	uci:foreach("system", "system", function(s) --owm
-		position['latitude'] = tonumber(s.latitude) --owm
-		position['longitude'] = tonumber(s.longitude) --owm
+	uci:foreach("system", "system", function(s)
+		position['latitude'] = tonumber(s.latitude)
+		position['longitude'] = tonumber(s.longitude)
 	end)
 	return position
 end
@@ -272,8 +272,8 @@ function get()
 		root.freifunk[pname] = s
 	end)
 
-	root.latitude = position["latitude"]
-	root.longitude = position["longitude"]
+	root.latitude = position["latitude"] --owm
+	root.longitude = position["longitude"] --owm
 
 	local devices = {}
 	uci:foreach("wireless", "wifi-device",function(s)

--- a/utils/luci-app-owm/luasrc/owm.lua
+++ b/utils/luci-app-owm/luasrc/owm.lua
@@ -205,6 +205,15 @@ function showmac(mac)
 	return mac
 end
 
+function get_position()
+	local position = {}
+	uci:foreach("system", "system", function(s) --owm
+		position['latitude'] = tonumber(s.latitude) --owm
+		position['longitude'] = tonumber(s.longitude) --owm
+	end)
+	return position
+end
+
 function get()
 	local root = {}
 	local ntm = netm.init()
@@ -212,6 +221,7 @@ function get()
 	local assoclist = {}
 	local _ubus = bus.connect()
 	local _ubusclicache = { }
+	local position = get_position()
 --	local _, object
 --	for _, object in ipairs(_ubus:objects()) do
 --		local _ubusclicache = object:match("^clicache%.(.+)")
@@ -262,10 +272,8 @@ function get()
 		root.freifunk[pname] = s
 	end)
 
-	uci:foreach("system", "system", function(s) --owm
-		root.latitude = tonumber(s.latitude) --owm
-		root.longitude = tonumber(s.longitude) --owm
-	end)
+	root.latitude = position["latitude"]
+	root.longitude = position["longitude"]
 
 	local devices = {}
 	uci:foreach("wireless", "wifi-device",function(s)


### PR DESCRIPTION
when the latitude/longitude are not defined for the node, /usr/sbin/owm.lua tries to update the map anyway. such updates get refused by OWM-server 
> fail   Doc  Statuscode: 403 http://api.openwifimap.net//update_node/Ahof-frieden03.olsr ({"error":"forbidden","reason":"Document must have a longitude"}
)

so prevent script from running without the informations, which also saves a lot of processing time
<pre>
# current code
root@Ahof-frieden03:~# time /tmp/owm.lua
fail   Doc  Statuscode: 403 http://api.openwifimap.net//update_node/Ahof-frieden03.olsr ({"error":"forbidden","reason":"Document must have a longitude"}
)
real    0m 4.10s
user    0m 0.47s
sys     0m 0.13s

# new code
root@Ahof-frieden03:~# time /tmp/owm.lua 
real    0m 0.26s
user    0m 0.23s
sys     0m 0.03s
</pre>


code works on my node