### PR TITLE
remove "latlon" from uci: system.system (resend)

### DIFF
--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ffwizard-berlin
-PKG_VERSION:=0.0.1
+PKG_VERSION:=0.0.2
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
@@ -81,7 +81,6 @@ function commit()
   if not lonval or not latval then
     uci:foreach("system","system",
       function(s)
-        uci:delete("system", s[".name"], "latlon")
         uci:delete("system", s[".name"], "latitude")
         uci:delete("system", s[".name"], "longitude")
       end)

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
@@ -101,11 +101,9 @@ function main.write(self, section, value)
       uci:set("system", s[".name"], "timezone", 'CET-1CEST,M3.5.0,M10.5.0/3')
       uci:set("system", s[".name"], "hostname", hostname:formvalue(section))
       if (lonval and latval) then
-        uci:set("system", s[".name"], "latlon",string.format("%.15f %.15f", latval, lonval))
         uci:set("system", s[".name"], "latitude",string.format("%.15f", latval))
         uci:set("system", s[".name"], "longitude",string.format("%.15f", lonval))
       else
-        uci:delete("system", s[".name"], "latlon")
         uci:delete("system", s[".name"], "latitude")
         uci:delete("system", s[".name"], "longitude")
       end


### PR DESCRIPTION
- this removes the uci-setting "system.system.latlon"
- "latlon" seems to be only historic, also by checking the whole src-tree (relevant for Freifunk) there seems to be no active use of the parameter; only found some fallback in case "system.system.latitude" and "system.system.longitude" are not defined
- code seems to work fine on my systems
- this closes https://github.com/freifunk-berlin/firmware/issues/307
- is a resubmit of PR #61 

- is in public beta in all unstable-firmware images of https://github.com/freifunk-berlin/firmware/tree/unstable_SAm0815 without any known problems