### PR TITLE
extend "openvpn hotplug" to run via procd

### DIFF
--- a/utils/freifunk-berlin-openvpn-files/openvpn/60-ffopenvpn
+++ b/utils/freifunk-berlin-openvpn-files/openvpn/60-ffopenvpn
@@ -20,15 +20,17 @@ config_get uci_vpn_enabled ffvpn enabled
 
 if [ "$ACTION" = ifup ]; then
   logger -t ff-userlog "WAN interface is up, starting OpenVPN"
+  # Make sure OpenVPN connects only through WAN: set "local" option with WAN IP
+  local wanip
+  network_get_ipaddr wanip "wan"
   if [ "$uci_vpn_enabled" = 1 ]; then
     logger -t ff-vpn-hotplug "Using UCI OpenVPN configuration"
+    uci set openvpn.ffvpn.local=$wanip
+    uci commit openvpn
     /etc/init.d/openvpn start
     exit
   fi
   logger -t ff-vpn-hotplug "Using built-in Berlin VPN03 configuration"
-  # Make sure OpenVPN connects only through WAN: set "local" option with WAN IP
-  local wanip
-  network_get_ipaddr wanip "wan"
   openvpn --client --proto udp --dev ffvpn --dev-type tun --persist-key \
           --keepalive 10 60 --ns-cert-type server --comp-lzo no \
           --script-security 2 --cipher none --route-nopull --mssfix 1300 \

--- a/utils/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
+++ b/utils/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
@@ -9,6 +9,25 @@ uci delete openvpn.sample_client
 uci set openvpn.ffvpn=openvpn
 uci set openvpn.ffvpn.enabled=0
 uci set openvpn.ffvpn.client=1
+uci set openvpn.ffvpn.nobind=1
+uci set openvpn.ffvpn.proto=udp
+uci set openvpn.ffvpn.dev=ffvpn
+uci set openvpn.ffvpn.dev_type=tun
+uci set openvpn.ffvpn.persist_key=1
+uci set openvpn.ffvpn.keepalive="10 60"
+uci set openvpn.ffvpn.ns_cert_type=server
+uci set openvpn.ffvpn.comp_lzo="no"
+uci set openvpn.ffvpn.script_security=2
+uci set openvpn.ffvpn.cipher="none"
+uci set openvpn.ffvpn.mssfix=1300
+uci add_list openvpn.ffvpn.remote="vpn03.berlin.freifunk.net 1194 udp"
+uci add_list openvpn.ffvpn.remote="vpn03-backup.berlin.freifunk.net 1194 udp"
+uci set openvpn.ffvpn.ca="/etc/openvpn/freifunk-ca.crt"
+uci set openvpn.ffvpn.cert="/etc/openvpn/freifunk_client.crt"
+uci set openvpn.ffvpn.key="/etc/openvpn/freifunk_client.key"
+uci set openvpn.ffvpn.status="/var/log/openvpn-status-ffvpn.log"
+uci set openvpn.ffvpn.up="/lib/freifunk/ffvpn-up.sh"
+uci set openvpn.ffvpn.route_nopull=1
 uci commit openvpn
 
 uci set network.ffvpn=interface

--- a/utils/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
+++ b/utils/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
@@ -9,7 +9,6 @@ uci delete openvpn.sample_client
 uci set openvpn.ffvpn=openvpn
 uci set openvpn.ffvpn.enabled=0
 uci set openvpn.ffvpn.client=1
-uci set openvpn.ffvpn.nobind=1
 uci set openvpn.ffvpn.proto=udp
 uci set openvpn.ffvpn.dev=ffvpn
 uci set openvpn.ffvpn.dev_type=tun


### PR DESCRIPTION
- in recent OpenWRT CC the OpenVPN is run via procd
- using this daemon seems more reliable in case if OpenVPN-crashes
- using the default init-script also allows using default UCI-config
- also implements the nice idea binding to the WAN-interface to prevent OpenVPN over freifunk-mesh, and gets rid of using firewall-rules for blocking this traffic

also takes care of https://github.com/freifunk-berlin/firmware/issues/338