### PR TITLE
Fixes running migration even on fresh install

### DIFF
--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
-PKG_VERSION:=0.0.0
+PKG_VERSION:=0.1.0
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -1,18 +1,59 @@
 #!/usr/bin/env sh
 
 source /lib/functions/semver.sh
+source /etc/openwrt_release
 
-OLD_VERSION=$(uci get system.@system[0].version)
-# use default "0.0.0" in case nothing defined
-OLD_VERSION=${OLD_VERSION:-'0.0.0'}
+# possible cases: 
+# 1) firstboot with kathleen --> uci system.version not defined
+# 2) upgrade from kathleen --> uci system.version defined
+# 3) upgrade from non kathleen / legacy --> no uci system.version
+
+OLD_VERSION=$(uci -q get system.@system[0].version)
 # remove "special-version" e.g. "-alpha+3a7d"; only work on "basic" semver-strings
-OLD_VERSION=${OLD_VERSION%%-*}
-VERSION=$(cat /etc/openwrt_version)
+VERSION=${DISTRIB_RELEASE%%-*}
 
 log() {
   logger -s -t freifunk-berlin-migration $@
   echo >>/root/migrate.log $@
 }
+
+if [ "Freifunk Berlin" = "${DISTRIB_ID}" ]; then
+  log "Migration is running on a Freifunk Berlin system"
+else
+  log "no Freifunk Berlin system detected ..."
+  exit 0
+fi
+
+# when upgrading from a pre-kathleen installation, there sould be
+# at least on "very old file" in /etc/config ...
+#
+FOUND_OLD_FILE=false
+# create helper to compare file ctime (1. Sep. 2014)
+touch -d "201409010000" /tmp/timestamp
+for testfile in /etc/config/*; do
+  if [ "${testfile}" -ot /tmp/timestamp ]; then
+    FOUND_OLD_FILE=true
+    echo "guessing pre-kathleen firmware as of ${testfile}"
+  fi
+done
+rm -f /tmp/timestamp
+
+if [ -n "${OLD_VERSION}" ]; then
+  # case 2)
+  log "normal migration within Release ..."
+elif [ ${FOUND_OLD_FILE} = true ]; then
+  # case 3)
+  log "migrating from legacy Freifunk Berlin system ..."
+  OLD_VERSION='0.0.0'
+else
+  # case 1)
+  log "fresh install - no migration"
+  # add system.version with the new version
+  log "Setting new system version to ${VERSION}; no migration needed."
+  uci set system.@system[0].version=${VERSION}
+  uci commit
+  exit 0
+fi
 
 update_openvpn_remote_config() {
   # use dns instead of ips for vpn servers (introduced with 0.1.0)

--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -8,6 +8,7 @@ VERSION=$(cat /etc/openwrt_version)
 
 log() {
   logger -s -t freifunk-berlin-migration $@
+  echo >>/root/migrate.log $@
 }
 
 update_openvpn_remote_config() {

--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -3,7 +3,10 @@
 source /lib/functions/semver.sh
 
 OLD_VERSION=$(uci get system.@system[0].version)
+# use default "0.0.0" in case nothing defined
 OLD_VERSION=${OLD_VERSION:-'0.0.0'}
+# remove "special-version" e.g. "-alpha+3a7d"; only work on "basic" semver-strings
+OLD_VERSION=${OLD_VERSION%%-*}
 VERSION=$(cat /etc/openwrt_version)
 
 log() {


### PR DESCRIPTION
found that on a fresh install the migration-script gets started, when working on 
- https://github.com/freifunk-berlin/firmware-packages/pull/72
- https://github.com/freifunk-berlin/firmware-packages/pull/73

This is caused by the fact that UCI "system.version" in not defined and the default "0.0.0" is choosen.

Running migraition on fresh installs makes no sense and has the chance to break some settings.

This idea here, tries to find the difference between a fresh install (of a >= kathleen 0.2.0) firmware and running on a old firmware by looking for files older than the first kathleen-release. See "ctime" of file /tmp/timestamp for this (Line34).
Only the "basic" Semver numbers are taken into account when deciding on migration-steps. The current code as some problems with the version-string when a "special-version" (-alpha+xxx) is suffixed.

by this chance UCI "system.version" gets renamed to "system.kathleen_version". 