### PR TITLE
migration: add migration for removal of dhcp.lan config

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -117,6 +117,11 @@ fix_qos_interface() {
   uci delete qos.wan
 }
 
+remove_dhcp_interface_lan() {
+  uci -q delete dhcp.lan
+  uci commit dhcp
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -142,6 +147,7 @@ migrate () {
     add_firewall_rule_vpn03c
     update_collectd_ping
     fix_qos_interface
+    remove_dhcp_interface_lan
   fi
 
   # overwrite version with the new version


### PR DESCRIPTION
in addition to the https://github.com/freifunk-berlin/firmware-packages/pull/68 which became https://github.com/freifunk-berlin/firmware-packages/commit/cd4d319499338ff5b088a441acaed1847ea34d5c

we changed this th ffwizard, but forgot about a migration for this