### PR TITLE
[ffwizard] remove freifunk-watchdog configuration from assistent

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -118,7 +118,7 @@ fix_qos_interface() {
 }
 
 remove_freifunk_watchdog_from_crontab() {
-  crontab -l | grep "/usr/sbin/ffwatchd" && crontab -l | grep -v "/usr/sbin/ffwatchd" | crontab -
+  crontab -l | grep -v "/usr/sbin/ffwatchd" | crontab -
 }
 
 migrate () {

--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -117,6 +117,10 @@ fix_qos_interface() {
   uci delete qos.wan
 }
 
+remove_freifunk_watchdog_from_crontab() {
+  crontab -l | grep "/usr/sbin/ffwatchd" && crontab -l | grep -v "/usr/sbin/ffwatchd" | crontab -
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -142,6 +146,7 @@ migrate () {
     add_firewall_rule_vpn03c
     update_collectd_ping
     fix_qos_interface
+    remove_freifunk_watchdog_from_crontab
   fi
 
   # overwrite version with the new version

--- a/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
@@ -92,7 +92,6 @@ function commit()
   olsr.configureOLSR()
   olsr.configureOLSRPlugins()
 
-  tools.configureWatchdog()
   tools.configureQOS()
 
   uci:commit("dhcp")
@@ -104,7 +103,6 @@ function commit()
   uci:commit("freifunk")
   uci:commit("wireless")
   uci:commit("network")
-  uci:commit("freifunk-watchdog")
   uci:commit("qos")
 
   sys.init.enable("olsrd")
@@ -141,7 +139,6 @@ function reset()
   uci:revert("freifunk")
   uci:revert("wireless")
   uci:revert("network")
-  uci:revert("freifunk-watchdog")
   uci:revert("qos")
 
   if ipkg.installed("luci-app-statistics") == True then

--- a/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/ffwizard.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/ffwizard.lua
@@ -22,17 +22,6 @@ local sharenet = uci:get("ffwizard", "settings", "sharenet")
 
 module ("luci.tools.freifunk.assistent.ffwizard", package.seeall)
 
-function configureWatchdog()
-	if (sharenet =="1") then
-		uci:section("freifunk-watchdog", "process", nil, {
-			process="openvpn",
-			initscript="/etc/init.d/openvpn"
-		})
-		uci:save("freifunk-watchdog")
-	end
-end
-
-
 function configureQOS()
   if sharenet == "1" then
     -- values have to be in kilobits/second


### PR DESCRIPTION
Functionality provided by the freifunk-watchdog is now provided by procd. Other
functionality like a reboot at high load is nothing we need.

For a longer discussion please take a look at:

https://github.com/freifunk-berlin/firmware/issues/52

I think this need still needs a migration step.