### PR TITLE
fix migration on fresh install

### DIFF
--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
-PKG_VERSION:=0.0.0
+PKG_VERSION:=0.1.0
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -3,7 +3,10 @@
 source /lib/functions/semver.sh
 
 OLD_VERSION=$(uci get system.@system[0].version)
+# use default "0.0.0" in case nothing defined
 OLD_VERSION=${OLD_VERSION:-'0.0.0'}
+# remove "special-version" e.g. "-alpha+3a7d"; only work on "basic" semver-strings
+OLD_VERSION=${OLD_VERSION%%-*}
 VERSION=$(cat /etc/openwrt_version)
 
 log() {

--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -1,17 +1,58 @@
 #!/usr/bin/env sh
 
 source /lib/functions/semver.sh
+source /etc/openwrt_release
 
-OLD_VERSION=$(uci get system.@system[0].version)
-# use default "0.0.0" in case nothing defined
-OLD_VERSION=${OLD_VERSION:-'0.0.0'}
+# possible cases: 
+# 1) firstboot with kathleen --> uci system.version not defined
+# 2) upgrade from kathleen --> uci system.version defined
+# 3) upgrade from non kathleen / legacy --> no uci system.version
+
+OLD_VERSION=$(uci -q get system.@system[0].version)
 # remove "special-version" e.g. "-alpha+3a7d"; only work on "basic" semver-strings
-OLD_VERSION=${OLD_VERSION%%-*}
-VERSION=$(cat /etc/openwrt_version)
+VERSION=${DISTRIB_RELEASE%%-*}
 
 log() {
   logger -s -t freifunk-berlin-migration $@
 }
+
+if [ "Freifunk Berlin" = "${DISTRIB_ID}" ]; then
+  log "Migration is running on a Freifunk Berlin system"
+else
+  log "no Freifunk Berlin system detected ..."
+  exit 0
+fi
+
+# when upgrading from a pre-kathleen installation, there sould be
+# at least on "very old file" in /etc/config ...
+#
+FOUND_OLD_FILE=false
+# create helper to compare file ctime (1. Sep. 2014)
+touch -d "201409010000" /tmp/timestamp
+for testfile in /etc/config/*; do
+  if [ "${testfile}" -ot /tmp/timestamp ]; then
+    FOUND_OLD_FILE=true
+    echo "guessing pre-kathleen firmware as of ${testfile}"
+  fi
+done
+rm -f /tmp/timestamp
+
+if [ -n "${OLD_VERSION}" ]; then
+  # case 2)
+  log "normal migration within Release ..."
+elif [ ${FOUND_OLD_FILE} = true ]; then
+  # case 3)
+  log "migrating from legacy Freifunk Berlin system ..."
+  OLD_VERSION='0.0.0'
+else
+  # case 1)
+  log "fresh install - no migration"
+  # add system.version with the new version
+  log "Setting new system version to ${VERSION}; no migration needed."
+  uci set system.@system[0].version=${VERSION}
+  uci commit
+  exit 0
+fi
 
 update_openvpn_remote_config() {
   # use dns instead of ips for vpn servers (introduced with 0.1.0)


### PR DESCRIPTION
see https://github.com/freifunk-berlin/firmware/issues/340 (when setting up a router from scratch, the migration-script gets started)

this fixes this by assuming any install without UCI-setting system.version defined is a fresh install and there is no need for Migration.
There is also some kind of legacy-support to migrate "old freifunk"-systems (pre-kathleen) by checking for files created before kathleen was released.
When UCI-setting system.version is defined is acts straight forward.