### PR TITLE
[ffwizard] never try to auto-login if password has been set

### DIFF
--- a/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
@@ -33,7 +33,7 @@ function prepare()
     uci:save("ffwizard")
     uci:commit("ffwizard")
   end
-  if not uci:get("ffwizard","settings","runbefore") then
+  if not uci:get("ffwizard","settings","runbefore") and not uci:get("ffwizard", "settings", "passwordset") then
     luci.http.redirect(luci.dispatcher.build_url("admin/freifunk/assistent/changePassword"))
   else
     luci.http.redirect(luci.dispatcher.build_url("admin/freifunk/assistent/generalInfo"))

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/changePassword.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/changePassword.lua
@@ -34,6 +34,11 @@ function f.handle(self, state, data)
   if state == FORM_VALID then
     if data.pw1 and data.pw2 then
       local stat = luci.sys.user.setpasswd("root", data.pw1) == 0
+      if stat then
+        uci:set("ffwizard", "settings", "passwordset", "true")
+        uci:save("ffwizard")
+        uci:commit("ffwizard")
+      end
     end
     data.pw1 = nil
     data.pw2 = nil

--- a/utils/luci-mod-freifunk-ui/Makefile
+++ b/utils/luci-mod-freifunk-ui/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-mod-freifunk-ui
-PKG_VERSION:=0.0.1
-PKG_RELEASE:=2
+PKG_VERSION:=0.0.2
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/index.htm
+++ b/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/index.htm
@@ -22,9 +22,11 @@ local webAppRoot = http.getenv("PATH_INFO") == nil
 local notRunBefore = not uci.get("ffwizard", "settings", "runbefore")
 local notPasswordSet = not uci.get("ffwizard", "settings", "passwordset")
 local wizardInstalled = fs.access("/usr/lib/lua/luci/controller/assistent/assistent.lua")
-if (webAppRoot and notRunBefore and notPasswordSet and wizardInstalled) then
+if (webAppRoot and notRunBefore and wizardInstalled) then
 	local url = luci.dispatcher.build_url("admin/freifunk/assistent")
-	url = url .. "?luci_username=root&luci_password="
+	if (notPasswordSet) then
+		url = url .. "?luci_username=root&luci_password="
+	end
 	http.redirect(url)
 end
 %>

--- a/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/index.htm
+++ b/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/index.htm
@@ -16,12 +16,13 @@ local disp = require "luci.dispatcher"
 local ipkg = require "luci.model.ipkg"
 
 -- only redirect if assistent is installed and no root password is set
--- we use isfile because the view is run as root and we can't use e.g.
--- ipkg.installed or checkpasswd
+-- we use isfile because the view is not run as root and we can't use
+-- e.g. ipkg.installed or checkpasswd
 local webAppRoot = http.getenv("PATH_INFO") == nil
 local notRunBefore = not uci.get("ffwizard", "settings", "runbefore")
+local notPasswordSet = not uci.get("ffwizard", "settings", "passwordset")
 local wizardInstalled = fs.access("/usr/lib/lua/luci/controller/assistent/assistent.lua")
-if (webAppRoot and notRunBefore and wizardInstalled) then
+if (webAppRoot and notRunBefore and notPasswordSet and wizardInstalled) then
 	local url = luci.dispatcher.build_url("admin/freifunk/assistent")
 	url = url .. "?luci_username=root&luci_password="
 	http.redirect(url)


### PR DESCRIPTION
If a user sets a password but doesn't finish the set up process in
the wizard, the initial ffwizard auto-login redirect fails. This
adds a flag so that no auto-login happens if a password has been set.
Fixes https://github.com/freifunk-berlin/firmware/issues/208
