### PR TITLE
Fix/owm stats for kathleen 0.2.0

### DIFF
--- a/utils/luci-app-owm/Makefile
+++ b/utils/luci-app-owm/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-owm
-PKG_RELEASE:=0.4.11
+PKG_RELEASE:=0.4.12
 
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)

--- a/utils/luci-app-owm/luasrc/owm.lua
+++ b/utils/luci-app-owm/luasrc/owm.lua
@@ -24,6 +24,7 @@ local status = require "luci.tools.status"
 local json = require "luci.json"
 local netm = require "luci.model.network"
 local sysinfo = luci.util.ubus("system", "info") or { }
+local boardinfo = luci.util.ubus("system", "board") or { }
 local table = require "table"
 local nixio = require "nixio"
 --local neightbl = require "neightbl"
@@ -251,7 +252,7 @@ function get()
 	root.hostname = sys.hostname() --owm
 
 
-	root.hardware = "unknown" --owm TODO
+	root.hardware = boardinfo['system'] --owm
 	
 
 	root.firmware = {

--- a/utils/luci-app-owm/luasrc/owm.lua
+++ b/utils/luci-app-owm/luasrc/owm.lua
@@ -39,6 +39,27 @@ local ipairs, os, pairs, next, type, tostring, tonumber, error, print =
 module "luci.owm"
 
 
+-- backported from LuCI 0.11 and adapted form berlin-stats
+--- Returns the system type (in a compatible way to LuCI 0.11)
+-- @return	String indicating this as an deprecated value
+--        	(instead of the Chipset-type)
+-- @return	String containing hardware model information
+--        	(trimmed to router-model only)
+function sysinfo_for_kathleen020()
+	local cpuinfo = nixio.fs.readfile("/proc/cpuinfo")
+
+	local system = 'system is deprecated'
+
+	local model = 
+		boardinfo['model'] or
+		cpuinfo:match("machine\t+: ([^\n]+)") or
+		cpuinfo:match("Hardware\t+: ([^\n]+)") or
+		nixio.uname().machine or
+		system
+
+        return system, model
+end
+
 function fetch_olsrd_config()
 	local jsonreq4 = ""
 	local jsonreq6 = ""
@@ -247,7 +268,7 @@ function get()
 	root.system = {
 		uptime = {sys.uptime()},
 		loadavg = {sysinfo.load[1] / 65536.0},
-		sysinfo = {sysinfo},
+		sysinfo = {sysinfo_for_kathleen020()},
 	}
 	root.hostname = sys.hostname() --owm
 


### PR DESCRIPTION
This code implements a compatible json-dataset to send Router-model and Chipset-type as in kathleen 0.1.2. 
So the statistics-wegpage will work as it is (see issue https://github.com/freifunk-berlin/firmware/issues/378#issuecomment-237082534).

You can copy the owm.lua to the router under /usr/lib/lua/luci to for direct testing