### PR TITLE
[ffwizard] add a note to check all settings after configuration

### DIFF
--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ffwizard-berlin
-PKG_VERSION:=0.0.3
+PKG_VERSION:=0.0.4
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/reboot.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/reboot.htm
@@ -19,6 +19,13 @@
       zu erreichen.
     </p>
     <p>
+      Auch wenn wir versuchen deinen Router bestm&ouml;glichst zu konfigurieren
+      pr&uuml;fe bitte die Einstellungen, insbesondere f&uuml;r das WLAN.<br>
+      Die rechtlichen Vorschriften kannst du im 
+      <a href="https://wiki.freifunk.net/FAQ_Rechtliches#Welche_rechtlichen_Grundlagen_m.C3.BCssen_beachtet_werden.3F">
+      Freifunk-Wiki</a> nachlesen.
+    </p>
+    <p>
       Es gibt auch Services im Freifunk-Netz. Ein Liste kannst du dir
       im Freifunk-Hauptmenu unter "Services" ansehen,
       sobald dein Router neugestartet hat.


### PR DESCRIPTION
Inform the user to check the settings done by the assistent. This is
recommended esp. for the WiFi-settings as some there are some routers
that might have incorrect defaults.