### PR TITLE
network-defaults: add workaround for too high txpower on some units

### DIFF
--- a/utils/freifunk-berlin-network-defaults/Makefile
+++ b/utils/freifunk-berlin-network-defaults/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-network-defaults
-PKG_VERSION:=0.0.1
-PKG_RELEASE:=1
+PKG_VERSION:=0.0.2
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -13,7 +13,7 @@ define Package/freifunk-berlin-network-defaults
   CATEGORY:=freifunk-berlin
   TITLE:=Freifunk Berlin network default configuration
   URL:=http://github.com/freifunk-berlin/packages_berlin
-  DEPENDS+= +freifunk-berlin-lib-guard
+  DEPENDS+= +freifunk-berlin-lib-guard +iwinfo
 endef
 
 define Package/freifunk-berlin-network-defaults/description

--- a/utils/freifunk-berlin-network-defaults/uci-defaults/freifunk-berlin-correct-nsm2-txpower
+++ b/utils/freifunk-berlin-network-defaults/uci-defaults/freifunk-berlin-correct-nsm2-txpower
@@ -1,0 +1,31 @@
+#!/bin/ash
+#
+# For Ubiquiti the default TX-power on OpenWrt is above regulatory limits.
+# see https://github.com/freifunk-berlin/firmware/issues/381
+#
+
+iwinfo|grep -q 'NanoStation M2\|NanoStation Loco M2' || exit 0
+
+. /lib/functions/guard.sh
+guard "NSm2_txpower"
+
+set_default_txpower() {
+ echo "setting txpower value to $1 dBm"
+ uci set wireless.radio0.txpower=$1
+ uci commit wireless
+}
+
+MAX_TX_2G=20
+# get "TX offset" of 1st interface, if this is unknown set it to 0dB
+# then only return the numerical value
+ANT_GAIN=$(iwinfo |grep -m 1 "TX power offset:" |sed -e "s/unknown/0 dB/" |tr -dc '0-9')
+NEW_TX=$(echo $(($MAX_TX_2G - $ANT_GAIN)))
+
+CURR_TX=$(uci -q get wireless.radio0.txpower)
+# check if txpower is defined in config
+if [ $? -ne 0 ]; then
+  echo -n "txpower not defined - "
+  set_default_txpower $NEW_TX
+elif [ $CURR_TX -gt $NEW_TX ]; then
+  set_default_txpower $NEW_TX
+fi


### PR DESCRIPTION
this is a workaround for https://github.com/freifunk-berlin/firmware/issues/381.
Some units (esp. Nanostations M2) use a too high TX-power by default, caused by
upstream.
This script relies on iwinfo where antenna-gains can be defined and just
subtracts the gain from the allowed upper limit.
It only runs once per router, as of guard "2GHz_txpower"

The currently known router with antenna-gains other than "0" have only one
wifi-phy, so only one PHY needs to be checked. Even this interface is by OpenWRT-
default "wlan0" and per Freifunk-default "wlan0-dhcp-2" and "wlan0-adhoc-2"
