### PR TITLE
[olsrd-defaults] fix filename of olsr6 watchdog file

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -216,6 +216,11 @@ delete_system_latlon() {
   uci commit system
 }
 
+fix_olsrd6_watchdog_file() {
+  log "fix olsrd6 watchdog file"
+  uci set $(uci show olsrd6|grep "/var/run/olsrd.watchdog"|cut -d '=' -f 1)=/var/run/olsrd6.watchdog
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -245,6 +250,7 @@ migrate () {
     change_olsrd_dygw_ping
     fix_dhcp_start_limit
     delete_system_latlon
+    fix_olsrd6_watchdog_file
   fi
 
   # overwrite version with the new version

--- a/utils/freifunk-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
+++ b/utils/freifunk-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
@@ -110,7 +110,7 @@ uci set olsrd6.$PLUGIN.ipv6only=true
 # add watchdog plugin
 PLUGIN="$(uci add olsrd6 LoadPlugin)"
 uci set olsrd6.$PLUGIN.library=olsrd_watchdog.so.0.1
-uci set olsrd6.$PLUGIN.file=/var/run/olsrd.watchdog
+uci set olsrd6.$PLUGIN.file=/var/run/olsrd6.watchdog
 uci set olsrd6.$PLUGIN.interval=30
 
 # set olsrd defaults


### PR DESCRIPTION
see
https://lists.berlin.freifunk.net/pipermail/berlin/2016-November/034556.html

We should fix this in any case (even if we use procd instead of ffwatchd) because it's a config bug anyways.