### PR TITLE
[dhcp-defaults] quieten dnsmasq

### DIFF
--- a/utils/freifunk-berlin-dhcp-defaults/files/etc/init.d/ff_dnsmasq_reload
+++ b/utils/freifunk-berlin-dhcp-defaults/files/etc/init.d/ff_dnsmasq_reload
@@ -2,13 +2,19 @@
 
 START=88
 
+# This triggers rereading dnsmasq config in case
+# /tmp/hosts/olsr has changed which is used by the
+# olsrd_nameservice plugin.
+
 boot() {
 	test -f /etc/crontabs/root || touch /etc/crontabs/root
 
-	grep -q 'killall -HUP dnsmasq' /etc/crontabs/root || {
-		echo "*/5 * * * *	killall -HUP dnsmasq" >> /etc/crontabs/root
-	}
+	touch /tmp/dnsmasq.stamp
 
-	/etc/init.d/cron restart &
+	CHECK_DNSMASQ="[ /tmp/hosts/olsr -nt /tmp/dnsmasq.stamp ] && touch /tmp/dnsmasq.stamp && killall -HUP dnsmasq"
+	grep -q -F "$CHECK_DNSMASQ" /etc/crontabs/root || {
+		echo "*/5 * * * *	$CHECK_DNSMASQ" >> /etc/crontabs/root
+		/etc/init.d/cron restart &
+	}
 }
 

--- a/utils/freifunk-berlin-dhcp-defaults/uci-defaults/freifunk-berlin-dhcp-defaults
+++ b/utils/freifunk-berlin-dhcp-defaults/uci-defaults/freifunk-berlin-dhcp-defaults
@@ -3,6 +3,8 @@
 . /lib/functions/guard.sh
 guard "dhcp"
 
+# quieten down dnsmasq a bit
+uci set dhcp.@dnsmasq[0].quietdhcp=1
 
 # add dns entry frei.funk
 uci set dhcp.frei_funk=domain

--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -219,6 +219,11 @@ delete_system_latlon() {
 fix_olsrd6_watchdog_file() {
   log "fix olsrd6 watchdog file"
   uci set $(uci show olsrd6|grep "/var/run/olsrd.watchdog"|cut -d '=' -f 1)=/var/run/olsrd6.watchdog
+
+quieten_dnsmasq() {
+  log "quieten dnsmasq"
+  crontab -l | grep -v '\* \* \* \*	killall -HUP dnsmasq' | crontab -
+  uci set dhcp.@dnsmasq[0].quietdhcp=1
 }
 
 migrate () {
@@ -251,6 +256,7 @@ migrate () {
     fix_dhcp_start_limit
     delete_system_latlon
     fix_olsrd6_watchdog_file
+    quieten_dnsmasq
   fi
 
   # overwrite version with the new version


### PR DESCRIPTION
reload only if /tmp/hosts/olsr has changed; set quiet-dhcp dnsmasq option

fixes https://github.com/freifunk-berlin/firmware/issues/401