### PR TITLE
[migration] update OWM API URL

### DIFF
--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
-PKG_VERSION:=0.1.2
+PKG_VERSION:=0.2.0
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -216,6 +216,13 @@ delete_system_latlon() {
   uci commit system
 }
 
+update_berlin_owm_api() {
+  if [ "$(uci get freifunk.community.name)" = "berlin" ]; then
+    log "updating Berlin OWM API URL"
+    uci set freifunk.community.owm_api="http://util.berlin.freifunk.net"
+  fi
+}
+
 fix_olsrd6_watchdog_file() {
   log "fix olsrd6 watchdog file"
   uci set $(uci show olsrd6|grep "/var/run/olsrd.watchdog"|cut -d '=' -f 1)=/var/run/olsrd6.watchdog
@@ -242,6 +249,7 @@ migrate () {
   fi
 
   if semverLT ${OLD_VERSION} "0.2.0"; then
+    update_berlin_owm_api
     update_collectd_ping
     fix_qos_interface
     remove_dhcp_interface_lan


### PR DESCRIPTION
This sets the OWM API URL to a Berlin specific one so we can have
some features like encrypted mail addresses, automated contact
forms, other map data formats, other backend databases etc.
easily without having to update all clients later.

Setting owm_api in the profile is better than changing the default
in owm.lua since the latter would (in the long run) break OWM for
other communities using Kathleen.