### PR TITLE
make all packages arch independent

### DIFF
--- a/utils/collectd-snmp-templates/Makefile
+++ b/utils/collectd-snmp-templates/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd-snmp-templates
 PKG_VERSION:=0.0.1
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 UBIQUITI_MIBS_REL=ubnt-mibs_20160803.zip
 
@@ -23,6 +23,7 @@ define Package/collectd-snmp-templates
   TITLE:=Templates to gather statistics from different SNMP-nodes
   URL:=http://github.com/freifunk-berlin/packages_berlin
   DEPENDS+= +collectd-mod-snmp +snmp-mibs
+  PKGARCH:=all
 endef
 
 define Package/collectd-snmp-templates/description

--- a/utils/freifunk-berlin-dhcp-defaults/Makefile
+++ b/utils/freifunk-berlin-dhcp-defaults/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-dhcp-defaults
 PKG_VERSION:=0.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -14,6 +14,7 @@ define Package/freifunk-berlin-dhcp-defaults
   TITLE:=Freifunk Berlin dhcp default configuration
   URL:=http://github.com/freifunk-berlin/packages_berlin
   DEPENDS+= +dnsmasq +freifunk-berlin-lib-guard
+  PKGARCH:=all
 endef
 
 define Package/freifunk-berlin-dhcp-defaults/description

--- a/utils/freifunk-berlin-firewall-defaults/Makefile
+++ b/utils/freifunk-berlin-firewall-defaults/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-firewall-defaults
 PKG_VERSION:=0.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -14,6 +14,7 @@ define Package/freifunk-berlin-firewall-defaults
   TITLE:=Freifunk Berlin firewall default configuration
   URL:=http://github.com/freifunk-berlin/packages_berlin
   DEPENDS+= +firewall +freifunk-berlin-lib-guard
+  PKGARCH:=all
 endef
 
 define Package/freifunk-berlin-firewall-defaults/description

--- a/utils/freifunk-berlin-freifunk-defaults/Makefile
+++ b/utils/freifunk-berlin-freifunk-defaults/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-freifunk-defaults
 PKG_VERSION:=0.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -13,6 +13,7 @@ define Package/freifunk-berlin-freifunk-defaults
   CATEGORY:=freifunk-berlin
   TITLE:=Freifunk Berlin freifunk default configuration
   URL:=http://github.com/freifunk-berlin/packages_berlin
+  PKGARCH:=all
 endef
 
 define Package/freifunk-berlin-freifunk-defaults/description

--- a/utils/freifunk-berlin-lib-guard/Makefile
+++ b/utils/freifunk-berlin-lib-guard/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-lib-guard
 PKG_VERSION:=0.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -13,6 +13,7 @@ define Package/freifunk-berlin-lib-guard
   CATEGORY:=freifunk-berlin
   TITLE:=Freifunk Berlin guard function
   URL:=http://github.com/freifunk-berlin/packages_berlin
+  PKGARCH:=all
 endef
 
 define Package/freifunk-berlin-lib-guard/description

--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
 PKG_VERSION:=0.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -13,6 +13,7 @@ define Package/freifunk-berlin-migration
   CATEGORY:=freifunk-berlin
   TITLE:=Freifunk Berlin configuration migration script
   URL:=http://github.com/freifunk-berlin/packages_berlin
+  PKGARCH:=all
 endef
 
 define Package/freifunk-berlin-migration/description

--- a/utils/freifunk-berlin-network-defaults/Makefile
+++ b/utils/freifunk-berlin-network-defaults/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-network-defaults
 PKG_VERSION:=0.0.2
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -14,6 +14,7 @@ define Package/freifunk-berlin-network-defaults
   TITLE:=Freifunk Berlin network default configuration
   URL:=http://github.com/freifunk-berlin/packages_berlin
   DEPENDS+= +freifunk-berlin-lib-guard +iwinfo
+  PKGARCH:=all
 endef
 
 define Package/freifunk-berlin-network-defaults/description

--- a/utils/freifunk-berlin-olsrd-defaults/Makefile
+++ b/utils/freifunk-berlin-olsrd-defaults/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-olsrd-defaults
 PKG_VERSION:=0.0.3
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -14,6 +14,7 @@ define Package/freifunk-berlin-olsrd-defaults
   TITLE:=Freifunk Berlin olsrd default configuration
   URL:=http://github.com/freifunk-berlin/packages_berlin
   DEPENDS+= +olsrd +freifunk-berlin-lib-guard
+  PKGARCH:=all
 endef
 
 define Package/freifunk-berlin-olsrd-defaults/description

--- a/utils/freifunk-berlin-openvpn-files/Makefile
+++ b/utils/freifunk-berlin-openvpn-files/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-openvpn-files
 PKG_VERSION:=0.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -16,6 +16,7 @@ define Package/freifunk-berlin-openvpn-files
   TITLE:=Freifunk Berlin openVPN files
   URL:=http://github.com/freifunk-berlin/packages_berlin
   DEPENDS+= +openvpn-polarssl +freifunk-berlin-lib-guard
+  PKGARCH:=all
 endef
 
 define Package/freifunk-berlin-openvpn-files/description

--- a/utils/freifunk-berlin-statistics-defaults/Makefile
+++ b/utils/freifunk-berlin-statistics-defaults/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-statistics-defaults
 PKG_VERSION:=0.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -14,6 +14,7 @@ define Package/freifunk-berlin-statistics-defaults
   TITLE:=Freifunk Berlin statistics default configuration
   URL:=http://github.com/freifunk-berlin/packages_berlin
   DEPENDS+= +olsrd-mod-txtinfo +freifunk-berlin-lib-guard
+  PKGARCH:=all
 endef
 
 define Package/freifunk-berlin-statistics-defaults/description

--- a/utils/freifunk-berlin-uhttpd-defaults/Makefile
+++ b/utils/freifunk-berlin-uhttpd-defaults/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uhttpd-defaults
 PKG_VERSION:=0.0.1
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -14,6 +14,7 @@ define Package/freifunk-berlin-uhttpd-defaults
   TITLE:=Freifunk Berlin uhttpd default configuration
   URL:=http://github.com/freifunk-berlin/packages_berlin
   DEPENDS+= +uhttpd +freifunk-berlin-lib-guard
+  PKGARCH:=all
 endef
 
 define Package/freifunk-berlin-uhttpd-defaults/description

--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ffwizard-berlin
 PKG_VERSION:=0.0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -17,6 +17,7 @@ define Package/luci-app-ffwizard-berlin
   TITLE:=Freifunk Berlin configuration wizard
   URL:=http://berlin.freifunk.net
   DEPENDS+= +luci-base +luci-mod-admin-full +freifunk-policyrouting +freifunk-berlin-openvpn-files
+  PKGARCH:=all
 endef
 
 define Package/luci-app-ffwizard-berlin/description

--- a/utils/luci-app-owm/Makefile
+++ b/utils/luci-app-owm/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-owm
-PKG_RELEASE:=0.4.12
+PKG_RELEASE:=0.4.13
 
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
@@ -22,6 +22,7 @@ define Package/luci-app-owm/default
   CATEGORY:=LuCI
   SUBMENU:=3. Applications
   URL:=https://github.com/freifunk/packages-pberg/
+  PKGARCH:=all
 endef
 
 define Package/luci-app-owm

--- a/utils/luci-mod-freifunk-ui/Makefile
+++ b/utils/luci-mod-freifunk-ui/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-mod-freifunk-ui
 PKG_VERSION:=0.0.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -21,6 +21,7 @@ define Package/luci-mod-freifunk-ui
   SUBMENU:=2. Modules
   TITLE:=Freifunk Public and Admin LuCI UI
   DEPENDS:=+luci-mod-admin-full +luci-lib-json
+  PKGARCH:=all
 endef
 
 define Build/Prepare


### PR DESCRIPTION
all our packages are only scripts (shell or lua) / just datafiles which do not depend on a specific CPU-arch. 
This changes makes them cross-installable on all archs and even currently unsupported archs.

build this locally and works as before. Hope to get it into kathleen-0.2.0 as there is no functional change.