### PR TITLE
added support for reading wifi channel from community profile

### DIFF
--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ffwizard-berlin
-PKG_VERSION:=0.0.4
+PKG_VERSION:=0.0.5
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -346,15 +346,15 @@ function getchannel(device)
   local iwinfo = get_iwinfo(device)
   local freqlist = iwinfo.freqlist(device)
 
-  --TODO read channels from profile
+  local community = "profile_"..uci:get("freifunk", "community", "name")
   local r_channel
   if (freqlist[1].mhz > 2411 and freqlist[1].mhz < 2484) then
     --this is 2.4 Ghz
-    r_channel = 13
+    r_channel = tonumber(uci:get(community, "wifi_device", "channel")) or 13
   end
   if (freqlist[1].mhz > 5179 and freqlist[1].mhz < 5701) then
     --this is 5 Ghz
-    r_channel = 36
+    r_channel = tonumber(uci:get(community, "wifi_devicei_5", "channel")) or 36
   end
   tools.logger("channel for device "..device.." is "..tostring(r_channel))
   return r_channel

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -354,7 +354,7 @@ function getchannel(device)
   end
   if (freqlist[1].mhz > 5179 and freqlist[1].mhz < 5701) then
     --this is 5 Ghz
-    r_channel = tonumber(uci:get(community, "wifi_devicei_5", "channel")) or 36
+    r_channel = tonumber(uci:get(community, "wifi_device_5", "channel")) or 36
   end
   tools.logger("channel for device "..device.." is "..tostring(r_channel))
   return r_channel


### PR DESCRIPTION
Hey, I added support to read out the wirless channel from the community profile for the luci-app-ffwizard-berlin. So it is not hardcoded to 13 and 36.