### PR TITLE
owm: send release-name in field firmware.name

### DIFF
--- a/utils/luci-app-owm/Makefile
+++ b/utils/luci-app-owm/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-owm
-PKG_RELEASE:=0.4.13
+PKG_RELEASE:=0.4.14
 
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)


### PR DESCRIPTION
currently the complete release-name is send in field firmware.release only
("firmware":{"name":"","revision":"Freifunk Berlin kathleen 0.1.2"}). With
new OpenWrt 15.05 / LuCI automatically the revision is added to this.

this makes sorting / grouping by relase difficult and requires some
extra steps on client-side.

This change corrects the datafields as follows:
"firmware":{"name":"Freifunk Berlin kathleen 0.2.0","revision":"git affe"}
- "name" is DISTRIB_ID + DISTRIB_CODENAME + DISTRIB_RELEASE
- "revision" is DISTRIB_REVISION
- use owm.get_version in place of luci.version
- rely on "/etc/openwrt_release" as original luci.version