### PR TITLE
ffwizard: switch to new path of upload-dir

### DIFF
--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
@@ -71,11 +71,11 @@ function main.write(self, section, value)
   })
 
   fs.move(
-    "/lib/uci/upload/cbid.ffvpn.1.cert",
+    "/etc/luci-uploads/cbid.ffvpn.1.cert",
     "/etc/openvpn/freifunk_client.crt"
   )
   fs.move(
-    "/lib/uci/upload/cbid.ffvpn.1.key",
+    "/etc/luci-uploads/cbid.ffvpn.1.key",
     "/etc/openvpn/freifunk_client.key"
   )
 


### PR DESCRIPTION
LuCI-upload directory changed from /lib/uci/upload to /etc/luci-uploads in upstream 
(modules/luci-base: Move LuCI FileUpload directory to /etc/luci-uploads and save across sysupgrade)

fixes https://github.com/freifunk-berlin/firmware/issues/421

tested with build http://buildbot.berlin.freifunk.net/buildbot/unstable/ar71xx-generic/160/default/freifunk-berlin-1.0.0-olsrd0903-alpha-49489be-gl-ar150-sysupgrade.bin

please wait for merge till after 0.3.0 release