### PR TITLE
change default hostname of unconfigured systems

### DIFF
--- a/defaults/freifunk-berlin-system-defaults/Makefile
+++ b/defaults/freifunk-berlin-system-defaults/Makefile
@@ -1,0 +1,39 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=freifunk-berlin-system-defaults
+PKG_VERSION:=0.0.1
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/freifunk-berlin-system-defaults
+  SECTION:=freifunk-berlin
+  CATEGORY:=freifunk-berlin
+  TITLE:=Freifunk Berlin system default configuration
+  URL:=http://github.com/freifunk-berlin/packages_berlin
+  DEPENDS+= +freifunk-berlin-lib-guard
+  PKGARCH:=all
+endef
+
+define Package/freifunk-berlin-system-defaults/description
+  Freifunk Berlin configuration files for basic system-files
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/freifunk-berlin-system-defaults/install
+	$(INSTALL_DIR) $(1)/etc/uci-defaults
+	$(CP) ./uci-defaults/* $(1)/etc/uci-defaults
+endef
+
+$(eval $(call BuildPackage,freifunk-berlin-system-defaults))

--- a/defaults/freifunk-berlin-system-defaults/uci-defaults/freifunk-berlin-system-defaults
+++ b/defaults/freifunk-berlin-system-defaults/uci-defaults/freifunk-berlin-system-defaults
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+#. /lib/functions/guard.sh
+#guard "system"
+
+# change default hostname
+if [ $(uci get system.@system[0].hostname) = LEDE ]; then
+  uci set system.@system[0].hostname=gib-mir-einen-namen
+fi
+
+uci commit system

--- a/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
@@ -49,8 +49,8 @@ function commit()
 
   local community = "profile_"..uci:get("freifunk","community","name")
 
-  --change hostname to mesh ip if it is still Openwrt-something
-  if (not uci:get_first("system","system","hostname") or string.sub(uci:get_first("system","system","hostname"),1,string.len("OpenWrt"))=="OpenWrt") then
+  --change hostname to mesh ip if it is still the default (Openwrt-something, LEDE, e.g.)
+  if string.sub(uci:get_first("system","system","hostname"),1,string.len("gib-mir-einen-namen"))=="gib-mir-einen-namen" then
     local dhcpmesh = uci:get("ffwizard","settings","dhcpmesh")
     dhcpmesh = ip.IPv4(dhcpmesh):minhost()
     uci:foreach("system", "system",


### PR DESCRIPTION
* change the default hostname of unconfigured systems

----
PR123
* do not push a default-gw to the dhcp-clients on an unconfigured router
  * this prevents multihomed-clients to have to default-gw whenn configuring the router initially (this router will probably have no uplink at this time)
  * as the "LAN"-interface config will be deleted and replaced by "DHCP" there should be no problem after later setup (ffwizzard); backbone-images need to take care if they reuse the "LAN"-interface