### PR TITLE
network-defaults: disable 802.11b rates by default

### DIFF
--- a/utils/freifunk-berlin-network-defaults/Makefile
+++ b/utils/freifunk-berlin-network-defaults/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-network-defaults
-PKG_VERSION:=0.0.2
-PKG_RELEASE:=3
+PKG_VERSION:=0.0.3
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/utils/freifunk-berlin-network-defaults/uci-defaults/freifunk-berlin-wifi-defaults
+++ b/utils/freifunk-berlin-network-defaults/uci-defaults/freifunk-berlin-wifi-defaults
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+. /lib/functions/guard.sh
+guard "wifi"
+
+# disable 802.11b rates by default
+uci set wireless.radio0.legacy=0
+
+uci commit wireless


### PR DESCRIPTION
to save airtime and avoid client with bad connections
fixes https://github.com/freifunk-berlin/firmware/issues/375