### PR TITLE
owm: disable incompatible code section

### DIFF
--- a/utils/luci-app-owm/Makefile
+++ b/utils/luci-app-owm/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-owm
-PKG_RELEASE:=0.4.14
+PKG_RELEASE:=0.4.15
 
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)

--- a/utils/luci-app-owm/luasrc/owm.lua
+++ b/utils/luci-app-owm/luasrc/owm.lua
@@ -281,6 +281,10 @@ function get()
 	local _ubusclicache = { }
 	local position = get_position()
 	local version = get_version()
+--[[
+disabled this section as of incompatible luci-code
+see https://github.com/freifunk-berlin/firmware/issues/435
+
 --	local _, object
 --	for _, object in ipairs(_ubus:objects()) do
 --		local _ubusclicache = object:match("^clicache%.(.+)")
@@ -295,6 +299,7 @@ function get()
 			assoclist[#assoclist]['list'] = net.iwinfo.assoclist
 		end
 	end
+]]--
 	root.type = 'node' --owm
 	root.updateInterval = 3600 --owm one hour
 


### PR DESCRIPTION
some wifi-stuff has changed in current Lua / LuCI and breaks the whole script, that no data gets uploaded.
Disable affected section till it's fixed, to make OWM working somehow.

This is a temporary fix for https://github.com/freifunk-berlin/firmware/issues/435