### PR TITLE
luci-app-ffwizard-berlin: enable wifi-device by default

### DIFF
--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -145,6 +145,7 @@ function main.write(self, section, value)
       devconfig.doth = calcdoth(devconfig.channel)
       devconfig.htmode = "HT20"
       devconfig.chanlist = calcchanlist(devconfig.channel)
+      devconfig.disabled = "0"
       uci:tset("wireless", device, devconfig)
 
       --WIRELESS CONFIG ad-hoc


### PR DESCRIPTION
Enable wifi-device/radio by default in the assistent. Fixes an issue
with LEDE based builds where the 5GHz wifi-device is not enabled by
default after the wizard finished.

I'm not sure why the devices where enabled before. I can't find the
corresponding code.

Fixes https://github.com/freifunk-berlin/firmware/issues/441