### PR TITLE
freifunk-berlin-olsrd-defaults: explicitly set IpVersion to 6 for olsrd6

### DIFF
--- a/defaults/freifunk-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
+++ b/defaults/freifunk-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
@@ -115,6 +115,7 @@ uci set olsrd6.$PLUGIN.interval=30
 
 # set olsrd defaults
 OLSRD="$(uci add olsrd6 olsrd)"
+uci set olsrd6.$OLSRD.IpVersion=6
 uci set olsrd6.$OLSRD.FIBMetric=flat
 uci set olsrd6.$OLSRD.AllowNoInt=yes
 uci set olsrd6.$OLSRD.TcRedundancy=2

--- a/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/999_freifunk-berlin-migration.sh
@@ -238,6 +238,10 @@ vpn03_udp4() {
   uci set openvpn.ffvpn.proto=udp4
 }
 
+set_ipversion_olsrd6() {
+  uci set olsrd6.@olsrd[0].IpVersion=6
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -274,6 +278,10 @@ migrate () {
   if semverLT ${OLD_VERSION} "0.3.0"; then
     quieten_dnsmasq
     vpn03_udp4
+  fi
+
+  if semverLT ${OLD_VERSION} "1.0.0"; then
+    set_ipversion_olsrd6
   fi
 
   # overwrite version with the new version


### PR DESCRIPTION
If we don't set the IpVersion explicitly to 6 the startup of the daemon
fails because the IPv4 version of the txtinfo and jsoninfo plugin tries
to listen on 0::. If we don't set the IpVersion we start the IPv4
version of olsrd.

Fixes issue https://github.com/freifunk-berlin/firmware/issues/443