### PR TITLE
ffwizard: don't create cronjob to restart "wan"

### DIFF
--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
-PKG_VERSION:=0.4.1
-PKG_RELEASE:=2
+PKG_VERSION:=0.4.2
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -249,6 +249,10 @@ r1_0_0_vpn03_splitconfig() {
   guard openvpn # to guard the current settings of package "freifunk-berlin-openvpn-files"
 }
 
+r1_0_0_no_wan_restart() {
+  crontab -l | grep -v "^0 6 \* \* \* ifup wan$" | crontab -
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -290,6 +294,7 @@ migrate () {
   if semverLT ${OLD_VERSION} "1.0.0"; then
     set_ipversion_olsrd6
     r1_0_0_vpn03_splitconfig
+    r1_0_0_no_wan_restart
   fi
 
   # overwrite version with the new version

--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -3,8 +3,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ffwizard-berlin
-PKG_VERSION:=0.0.6
-PKG_RELEASE:=2
+PKG_VERSION:=0.0.7
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
@@ -113,7 +113,6 @@ function commit()
 
   if (sharenet == "1") then
     sys.init.enable("qos")
-    sys.exec('grep wan /etc/crontabs/root >/dev/null || echo "0 6 * * * ifup wan" >> /etc/crontabs/root')
   end
 
   if ipkg.installed("luci-app-statistics") == true then


### PR DESCRIPTION
there seems to be no reason to do this (anymore).
This code is there since initial commit of ffwizard, but no comment for what reason

see https://github.com/freifunk-berlin/firmware/issues/344