### PR TITLE
don't announce as default-gw during initial setup

### DIFF
--- a/defaults/freifunk-berlin-dhcp-defaults/Makefile
+++ b/defaults/freifunk-berlin-dhcp-defaults/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-dhcp-defaults
-PKG_VERSION:=0.0.1
-PKG_RELEASE:=2
+PKG_VERSION:=0.0.2
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/defaults/freifunk-berlin-dhcp-defaults/uci-defaults/freifunk-berlin-dhcp-defaults
+++ b/defaults/freifunk-berlin-dhcp-defaults/uci-defaults/freifunk-berlin-dhcp-defaults
@@ -17,4 +17,8 @@ uci set dhcp.frei_funk_ipv6=domain
 uci set dhcp.frei_funk_ipv6.name=frei.funk
 uci set dhcp.frei_funk_ipv6.ip=$router_ula
 
+# done send default-route to clients to prevent them sending pakets
+# to, we can't forward now
+uci add_list dhcp.lan.dhcp_option='3'
+
 uci commit dhcp


### PR DESCRIPTION
By default we will not announce ourself as default-gw to the clients, to prevent them sending us packets to forward, but not being configured yet.
So the client can be connected to his fully working network (via WiFI) and connect to us for configuration (via LAN), without breaking it's current connection.
As we do this on "LAN"-interface, which will be deleted by the wizard this will not cause problems on regular installs. Only systems configured by hand and keeping the LAN-interface, have to take care.