### PR TITLE
provide common interface for uplink-traffic

### DIFF
--- a/defaults/freifunk-berlin-firewall-defaults/Makefile
+++ b/defaults/freifunk-berlin-firewall-defaults/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-firewall-defaults
-PKG_VERSION:=0.0.3
+PKG_VERSION:=0.0.4
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/defaults/freifunk-berlin-firewall-defaults/uci-defaults/freifunk-berlin-firewall-defaults
+++ b/defaults/freifunk-berlin-firewall-defaults/uci-defaults/freifunk-berlin-firewall-defaults
@@ -84,12 +84,12 @@ uci set firewall.zone_freifunk.network=tunl0
 uci set firewall.zone_freifunk.device=tnl_+
 
 # add named zone section for the VPN-uplink
-uci set firewall.zone_ffvpn=zone
-uci set firewall.zone_ffvpn.name=ffvpn
-uci set firewall.zone_ffvpn.input=REJECT
-uci set firewall.zone_ffvpn.forward=ACCEPT
-uci set firewall.zone_ffvpn.output=ACCEPT
-uci set firewall.zone_ffvpn.network=ffvpn
+uci set firewall.zone_ffuplink=zone
+uci set firewall.zone_ffuplink.name=ffuplink
+uci set firewall.zone_ffuplink.input=REJECT
+uci set firewall.zone_ffuplink.forward=ACCEPT
+uci set firewall.zone_ffuplink.output=ACCEPT
+uci set firewall.zone_ffuplink.network=ffuplink
 
 FORWARDING="$(uci add firewall forwarding)"
 uci set firewall.$FORWARDING.dest=freifunk
@@ -131,8 +131,8 @@ FORWARDING="$(uci add firewall forwarding)"
 uci set firewall.$FORWARDING.dest=freifunk
 uci set firewall.$FORWARDING.src=wan
 
-uci set firewall.fwd_ff_ffvpn=forwarding
-uci set firewall.fwd_ff_ffvpn.src=freifunk
-uci set firewall.fwd_ff_ffvpn.dest=ffvpn
+uci set firewall.fwd_ff_ffuplink=forwarding
+uci set firewall.fwd_ff_ffuplink.src=freifunk
+uci set firewall.fwd_ff_ffuplink.dest=ffuplink
 
 uci commit firewall

--- a/defaults/freifunk-berlin-network-defaults/Makefile
+++ b/defaults/freifunk-berlin-network-defaults/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-network-defaults
-PKG_VERSION:=0.0.2
-PKG_RELEASE:=3
+PKG_VERSION:=0.0.3
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/defaults/freifunk-berlin-network-defaults/uci-defaults/freifunk-berlin-network-defaults
+++ b/defaults/freifunk-berlin-network-defaults/uci-defaults/freifunk-berlin-network-defaults
@@ -11,6 +11,9 @@ uci set network.lan.ipaddr=192.168.42.1
 uci set network.wan.peerdns=0
 uci set network.wan6.peerdns=0
 
+# setup wan as bridge
+uci set network.wan.type=bridge
+
 # add tunl0 interface - tunl0 is the ipip tunnel interface for the olsr
 # SmartGateway plugin
 uci set network.tunl0=interface

--- a/defaults/freifunk-berlin-openvpn-files/Makefile
+++ b/defaults/freifunk-berlin-openvpn-files/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-openvpn-files
-PKG_VERSION:=0.0.4
+PKG_VERSION:=0.0.5
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/defaults/freifunk-berlin-openvpn-files/openvpn/60-ffopenvpn
+++ b/defaults/freifunk-berlin-openvpn-files/openvpn/60-ffopenvpn
@@ -9,14 +9,14 @@ config_get sharenet settings sharenet
 
 [ "$sharenet" = 1 ] || exit
 
-[ "$INTERFACE" = ffvpn ] && [ "$ACTION" = ifup ] && logger -t ff-userlog "OpenVPN connection has been established"
-[ "$INTERFACE" = ffvpn ] && [ "$ACTION" = ifdown ] && logger -t ff-userlog "OpenVPN connection went down"
+[ "$INTERFACE" = ffuplink ] && [ "$ACTION" = ifup ] && logger -t ff-userlog "OpenVPN connection has been established"
+[ "$INTERFACE" = ffuplink ] && [ "$ACTION" = ifdown ] && logger -t ff-userlog "OpenVPN connection went down"
 
 [ "$INTERFACE" = wan ] || exit
 
 config_load openvpn
 local uci_vpn_enabled
-config_get uci_vpn_enabled ffvpn enabled
+config_get uci_vpn_enabled ffuplink enabled
 
 if [ "$ACTION" = ifup ]; then
   logger -t ff-userlog "WAN interface is up"
@@ -25,7 +25,7 @@ if [ "$ACTION" = ifup ]; then
     # Make sure OpenVPN connects only through WAN: set "local" option with WAN IP
     local wanip
     network_get_ipaddr wanip "wan"
-    uci set openvpn.ffvpn.local=$wanip
+    uci set openvpn.ffuplink.local=$wanip
     uci commit openvpn
     /etc/init.d/openvpn start
     exit

--- a/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
+++ b/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
@@ -8,7 +8,7 @@ uci delete openvpn.sample_server
 uci delete openvpn.sample_client
 uci commit openvpn
 
-uci set network.ffvpn=interface
-uci set network.ffvpn.ifname=ffvpn
-uci set network.ffvpn.proto=none
+uci set network.ffuplink=interface
+uci set network.ffuplink.ifname=ffuplink
+uci set network.ffuplink.proto=none
 uci commit network

--- a/defaults/freifunk-berlin-statistics-defaults/Makefile
+++ b/defaults/freifunk-berlin-statistics-defaults/Makefile
@@ -1,8 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-statistics-defaults
-PKG_VERSION:=0.0.1
-PKG_RELEASE:=2
+PKG_VERSION:=0.0.2
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/defaults/freifunk-berlin-statistics-defaults/uci-defaults/freifunk-berlin-statistics-defaults
+++ b/defaults/freifunk-berlin-statistics-defaults/uci-defaults/freifunk-berlin-statistics-defaults
@@ -39,7 +39,7 @@ uci set luci_statistics.collectd_ping.Hosts=ping.berlin.freifunk.net
 
 # mod interface
 uci set luci_statistics.collectd_interface=statistics
-uci set luci_statistics.collectd_interface.Interfaces=ffvpn
+uci set luci_statistics.collectd_interface.Interfaces=ffuplink
 uci set luci_statistics.collectd_interface.enable=1
 
 # mod load

--- a/defaults/freifunk-berlin-uplink-tunnelberlin-files/Makefile
+++ b/defaults/freifunk-berlin-uplink-tunnelberlin-files/Makefile
@@ -2,8 +2,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-tunnelberlin-files
-PKG_VERSION:=0.0.1
-PKG_RELEASE:=3
+PKG_VERSION:=0.0.2
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/defaults/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
+++ b/defaults/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
@@ -1,31 +1,31 @@
 #!/bin/sh
 
 # always set correct masquerading, regardless of guard
-uci set firewall.zone_ffvpn.masq=1
+uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
 . /lib/functions/guard.sh
 guard "tunnelberlin_openvpn"
 
-uci set openvpn.ffvpn=openvpn
-uci set openvpn.ffvpn.enabled=0
-uci set openvpn.ffvpn.client=1
-uci set openvpn.ffvpn.proto=udp4
-uci set openvpn.ffvpn.dev=ffvpn
-uci set openvpn.ffvpn.dev_type=tun
-uci set openvpn.ffvpn.persist_key=1
-uci set openvpn.ffvpn.keepalive="10 60"
-uci set openvpn.ffvpn.remote_cert_tls=server
-uci set openvpn.ffvpn.comp_lzo="no"
-uci set openvpn.ffvpn.script_security=2
-uci set openvpn.ffvpn.cipher="none"
-uci set openvpn.ffvpn.mssfix=1300
-uci add_list openvpn.ffvpn.remote="tunnel-gw.berlin.freifunk.net 1194"
-uci set openvpn.ffvpn.ca="/etc/openvpn/tunnel-berlin-ca.crt"
-uci set openvpn.ffvpn.extra_certs="/etc/openvpn/tunnel-berlin-extra.crt"
-uci set openvpn.ffvpn.cert="/etc/openvpn/freifunk_client.crt"
-uci set openvpn.ffvpn.key="/etc/openvpn/freifunk_client.key"
-uci set openvpn.ffvpn.status="/var/log/openvpn-status-ffvpn.log"
-uci set openvpn.ffvpn.up="/lib/freifunk/ffvpn-up.sh"
-uci set openvpn.ffvpn.route_nopull=1
+uci set openvpn.ffuplink=openvpn
+uci set openvpn.ffuplink.enabled=0
+uci set openvpn.ffuplink.client=1
+uci set openvpn.ffuplink.proto=udp4
+uci set openvpn.ffuplink.dev=ffuplink
+uci set openvpn.ffuplink.dev_type=tun
+uci set openvpn.ffuplink.persist_key=1
+uci set openvpn.ffuplink.keepalive="10 60"
+uci set openvpn.ffuplink.remote_cert_tls=server
+uci set openvpn.ffuplink.comp_lzo="no"
+uci set openvpn.ffuplink.script_security=2
+uci set openvpn.ffuplink.cipher="none"
+uci set openvpn.ffuplink.mssfix=1300
+uci add_list openvpn.ffuplink.remote="tunnel-gw.berlin.freifunk.net 1194"
+uci set openvpn.ffuplink.ca="/etc/openvpn/tunnel-berlin-ca.crt"
+uci set openvpn.ffuplink.extra_certs="/etc/openvpn/tunnel-berlin-extra.crt"
+uci set openvpn.ffuplink.cert="/etc/openvpn/ffuplink.crt"
+uci set openvpn.ffuplink.key="/etc/openvpn/ffuplink.key"
+uci set openvpn.ffuplink.status="/var/log/openvpn-status-ffuplink.log"
+uci set openvpn.ffuplink.up="/lib/freifunk/ffvpn-up.sh"
+uci set openvpn.ffuplink.route_nopull=1
 uci commit openvpn

--- a/defaults/freifunk-berlin-uplink-vpn03-files/Makefile
+++ b/defaults/freifunk-berlin-uplink-vpn03-files/Makefile
@@ -2,8 +2,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-vpn03-files
-PKG_VERSION:=0.0.3
-PKG_RELEASE:=4
+PKG_VERSION:=0.0.4
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/defaults/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
+++ b/defaults/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
@@ -1,31 +1,31 @@
 #!/bin/sh
 
 # always set correct masquerading, regardless of guard
-uci set firewall.zone_ffvpn.masq=0
+uci set firewall.zone_ffuplink.masq=0
 uci commit firewall
 
 . /lib/functions/guard.sh
 guard "vpn03_openvpn"
 
-uci set openvpn.ffvpn=openvpn
-uci set openvpn.ffvpn.enabled=0
-uci set openvpn.ffvpn.client=1
-uci set openvpn.ffvpn.proto=udp4
-uci set openvpn.ffvpn.dev=ffvpn
-uci set openvpn.ffvpn.dev_type=tun
-uci set openvpn.ffvpn.persist_key=1
-uci set openvpn.ffvpn.keepalive="10 60"
-uci set openvpn.ffvpn.ns_cert_type=server
-uci set openvpn.ffvpn.comp_lzo="no"
-uci set openvpn.ffvpn.script_security=2
-uci set openvpn.ffvpn.cipher="none"
-uci set openvpn.ffvpn.mssfix=1300
-uci add_list openvpn.ffvpn.remote="vpn03.berlin.freifunk.net 1194"
-uci add_list openvpn.ffvpn.remote="vpn03-backup.berlin.freifunk.net 1194"
-uci set openvpn.ffvpn.ca="/etc/openvpn/freifunk-ca.crt"
-uci set openvpn.ffvpn.cert="/etc/openvpn/freifunk_client.crt"
-uci set openvpn.ffvpn.key="/etc/openvpn/freifunk_client.key"
-uci set openvpn.ffvpn.status="/var/log/openvpn-status-ffvpn.log"
-uci set openvpn.ffvpn.up="/lib/freifunk/ffvpn-up.sh"
-uci set openvpn.ffvpn.route_nopull=1
+uci set openvpn.ffuplink=openvpn
+uci set openvpn.ffuplink.enabled=0
+uci set openvpn.ffuplink.client=1
+uci set openvpn.ffuplink.proto=udp4
+uci set openvpn.ffuplink.dev=ffuplink
+uci set openvpn.ffuplink.dev_type=tun
+uci set openvpn.ffuplink.persist_key=1
+uci set openvpn.ffuplink.keepalive="10 60"
+uci set openvpn.ffuplink.ns_cert_type=server
+uci set openvpn.ffuplink.comp_lzo="no"
+uci set openvpn.ffuplink.script_security=2
+uci set openvpn.ffuplink.cipher="none"
+uci set openvpn.ffuplink.mssfix=1300
+uci add_list openvpn.ffuplink.remote="vpn03.berlin.freifunk.net 1194"
+uci add_list openvpn.ffuplink.remote="vpn03-backup.berlin.freifunk.net 1194"
+uci set openvpn.ffuplink.ca="/etc/openvpn/freifunk-ca.crt"
+uci set openvpn.ffuplink.cert="/etc/openvpn/ffuplink.crt"
+uci set openvpn.ffuplink.key="/etc/openvpn/ffuplink.key"
+uci set openvpn.ffuplink.status="/var/log/openvpn-status-ffuplink.log"
+uci set openvpn.ffuplink.up="/lib/freifunk/ffvpn-up.sh"
+uci set openvpn.ffuplink.route_nopull=1
 uci commit openvpn

--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
-PKG_VERSION:=0.4.4
+PKG_VERSION:=0.4.5
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -3,8 +3,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ffwizard-berlin
-PKG_VERSION:=0.0.9
-PKG_RELEASE:=2
+PKG_VERSION:=0.0.10
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
@@ -2,7 +2,7 @@ local uci = require "luci.model.uci".cursor()
 local fs = require "nixio.fs"
 local tools = require "luci.tools.freifunk.assistent.tools"
 
-f = SimpleForm("ffvpn","","")
+f = SimpleForm("ffuplink","","")
 f.submit = "Next"
 f.cancel = "Back"
 f.reset = false
@@ -14,21 +14,21 @@ vpninfo = f:field(DummyValue, "vpninfo", "")
 vpninfo.template = "freifunk/assistent/snippets/vpninfo"
 
 if luci.http.formvalue("reupload", true) == "1" then
-  fs.unlink("/etc/openvpn/freifunk_client.crt")
-  fs.unlink("/etc/openvpn/freifunk_client.key")
+  fs.unlink("/etc/openvpn/ffuplink.crt")
+  fs.unlink("/etc/openvpn/ffuplink.key")
   luci.http.redirect(luci.dispatcher.build_url("admin/freifunk/assistent/sharedInternet"))
 end
-if fs.access("/etc/openvpn/freifunk_client.crt") then
+if fs.access("/etc/openvpn/ffuplink.crt") then
   vpncertreupload = f:field(DummyValue, "reupload", "")
   vpncertreupload.template = "freifunk/assistent/snippets/vpncertreupload"
 else
-  local cert = f:field(FileUpload, "cert", translate("Local Certificate"),"freifunk_client.crt")
-  cert.default="/etc/openvpn/freifunk_client.crt"
+  local cert = f:field(FileUpload, "cert", translate("Local Certificate"),"ffuplink.crt")
+  cert.default="/etc/openvpn/ffuplink.crt"
   cert.rmempty = false
   cert.optional = false
 
-  local key = f:field(FileUpload, "key", translate("Local Key"),"freifunk_client.key")
-  key.default="/etc/openvpn/freifunk_client.key"
+  local key = f:field(FileUpload, "key", translate("Local Key"),"ffuplink.key")
+  key.default="/etc/openvpn/ffuplink.key"
   key.rmempty = false
   key.optional = false
 end
@@ -65,18 +65,18 @@ function main.write(self, section, value)
   uci:set("ffwizard", "settings", "usersBandwidthUp", usersBandwidthUp:formvalue(section))
   uci:set("ffwizard", "settings", "usersBandwidthDown", usersBandwidthDown:formvalue(section))
 
-  uci:section("openvpn", "openvpn", "ffvpn", {
+  uci:section("openvpn", "openvpn", "ffuplink", {
     --persist_tun='0',
     enabled='1'
   })
 
   fs.move(
-    "/etc/luci-uploads/cbid.ffvpn.1.cert",
-    "/etc/openvpn/freifunk_client.crt"
+    "/etc/luci-uploads/cbid.ffuplink.1.cert",
+    "/etc/openvpn/ffuplink.crt"
   )
   fs.move(
-    "/etc/luci-uploads/cbid.ffvpn.1.key",
-    "/etc/openvpn/freifunk_client.key"
+    "/etc/luci-uploads/cbid.ffuplink.1.key",
+    "/etc/openvpn/ffuplink.key"
   )
 
   uci:save("openvpn")

--- a/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/ffwizard.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/ffwizard.lua
@@ -30,8 +30,8 @@ function configureQOS()
 
     uci:delete("qos","wan")
     uci:delete("qos","lan")
-    uci:delete("qos","ffvpn")
-    uci:section("qos", 'interface', "ffvpn", {
+    uci:delete("qos","ffuplink")
+    uci:section("qos", 'interface', "ffuplink", {
       enabled = "1",
       classgroup = "Default",
       upload = up,

--- a/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/olsr.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/olsr.lua
@@ -62,7 +62,7 @@ end
 function configureOLSRPlugins()
 	local suffix = uci:get_first(community, "community", "suffix") or "olsr"
 	updatePlugin("olsrd_nameservice.so.0.3", "suffix", "."..suffix)
-	updatePluginInConfig("olsrd", "olsrd_dyn_gw.so.0.5", "PingCmd", "ping -c 1 -q -I ffvpn %s")
+	updatePluginInConfig("olsrd", "olsrd_dyn_gw.so.0.5", "PingCmd", "ping -c 1 -q -I ffuplink %s")
 	updatePluginInConfig("olsrd", "olsrd_dyn_gw.so.0.5", "PingInterval", "30")
 	uci:save("olsrd")
 	uci:save("olsrd6")


### PR DESCRIPTION
This renames the current interface used to provide an uplink from "ffvpn" to "ffuplink", as discussed in https://github.com/freifunk-berlin/firmware/issues/472.

* Interface "WAN" becomes a bridge, to give other interfaces a way to connect to them.
* rename the interface in related default-scripts
* rename OpenVPN-certificates to "ffuplink.*" (OpenVPN-config + wizard)
* add a migration for this
