### PR TITLE
Fix index and shareInternet page.

### DIFF
--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ffwizard-berlin
-PKG_VERSION:=0.0.12
+PKG_VERSION:=0.0.13
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/shareInternet.lua
@@ -27,7 +27,7 @@ function usersBandwidthUp.cfgvalue(self, section)
   return uci:get("ffwizard", "settings", "usersBandwidthUp")
 end
 
-if uci.get("ffberlin-uplink", "uplink", "auth") == "x509" then
+if uci:get("ffberlin-uplink", "uplink", "auth") == "x509" then
   vpninfo = f:field(DummyValue, "vpninfo", "")
   vpninfo.template = "freifunk/assistent/snippets/vpninfo"
   if luci.http.formvalue("reupload", true) == "1" then

--- a/utils/luci-mod-freifunk-ui/Makefile
+++ b/utils/luci-mod-freifunk-ui/Makefile
@@ -8,8 +8,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-mod-freifunk-ui
-PKG_VERSION:=0.0.2
-PKG_RELEASE:=3
+PKG_VERSION:=0.0.3
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/index.htm
+++ b/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/index.htm
@@ -19,7 +19,7 @@ local ipkg = require "luci.model.ipkg"
 -- we use isfile because the view is not run as root and we can't use
 -- e.g. ipkg.installed or checkpasswd
 local webAppRoot = http.getenv("PATH_INFO") == nil
-local notRunBefore = not uci.get("ffwizard", "settings", "runbefore")
+local notRunBefore = not uci:get("ffwizard", "settings", "runbefore")
 local notPasswordSet = true
 local wizardInstalled = fs.access("/usr/lib/lua/luci/controller/assistent/assistent.lua")
 


### PR DESCRIPTION
due to some change in upstream projects the sites "shareInternet" and
"index" stopped working throwing an error
> A runtime error occured:
/usr/lib/lua/luci/model/uci.lua:157: attempt to call method 'get_all' (a
nil value)

Looks like we have to call get() like a method. Still i dont know why it did work before.