### PR TITLE
Migration for v1.0.1

### DIFF
--- a/defaults/freifunk-berlin-openvpn-files/Makefile
+++ b/defaults/freifunk-berlin-openvpn-files/Makefile
@@ -40,8 +40,6 @@ define Package/freifunk-berlin-openvpn-files/install
 	$(CP) ./openvpn/ffvpn-up.sh $(1)/lib/freifunk
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
 	$(CP) ./openvpn/60-ffopenvpn $(1)/etc/hotplug.d/iface
-	$(INSTALL_DIR) $(1)/etc/config
-	$(CP) ./files/ffberlin-uplink $(1)/etc/config
 endef
 
 $(eval $(call BuildPackage,freifunk-berlin-openvpn-files))

--- a/defaults/freifunk-berlin-openvpn-files/Makefile
+++ b/defaults/freifunk-berlin-openvpn-files/Makefile
@@ -3,8 +3,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-openvpn-files
-PKG_VERSION:=0.0.7
-PKG_RELEASE:=2
+PKG_VERSION:=0.0.8
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/defaults/freifunk-berlin-openvpn-files/files/ffberlin-uplink
+++ b/defaults/freifunk-berlin-openvpn-files/files/ffberlin-uplink
@@ -1,4 +1,0 @@
-
-config settings uplink
-        option auth 'x509'
-

--- a/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
+++ b/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# set set auth-type required for this uplink-type, e.g. for freifunk-wizard
+uci set ffberlin-uplink.uplink=settings
+uci set ffberlin-uplink.uplink.auth=x509
+
 uci -q delete openvpn.custom_config
 uci -q delete openvpn.sample_server
 uci -q delete openvpn.sample_client

--- a/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
+++ b/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
@@ -1,8 +1,10 @@
 #!/bin/sh
 
 # set set auth-type required for this uplink-type, e.g. for freifunk-wizard
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
 uci set ffberlin-uplink.uplink=settings
 uci set ffberlin-uplink.uplink.auth=x509
+uci commit ffberlin-uplink.uplink
 
 uci -q delete openvpn.custom_config
 uci -q delete openvpn.sample_server

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
@@ -40,8 +40,6 @@ define Package/$(PKG_NAME)/install
 	$(CP) ./uci-defaults/* $(1)/etc/uci-defaults
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
 	$(CP) ./files/60-ffuplink $(1)/etc/hotplug.d/iface
-	$(INSTALL_DIR) $(1)/etc/config
-	$(CP) ./files/ffberlin-uplink $(1)/etc/config
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-notunnel-files
-PKG_VERSION:=0.0.5
+PKG_VERSION:=0.0.6
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/files/ffberlin-uplink
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/files/ffberlin-uplink
@@ -1,4 +1,0 @@
-
-config settings uplink
-        option auth 'none'
-

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -1,19 +1,21 @@
 #!/bin/sh
 
-# set set auth-type required for this uplink-type, e.g. for freifunk-wizard
-uci set ffberlin-uplink.uplink=settings
-uci set ffberlin-uplink.uplink.auth=none
-
 # always set correct masquerading, regardless of guard
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-uci -q get ffberlin-uplink.preset=settings || uci set ffberlin-uplink.preset=settings
-uci >/dev/null -q get ffberlin-uplink.preset.current || uci -q set ffberlin-uplink.preset.current="no-tunnel"
-if [[ $(uci get ffberlin-uplink.preset.current) != 'no-tunnel' ]]; then
+# create ffberlin-uplink file an fill with basic settings
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
+uci >/dev/null -q get ffberlin-uplink.preset || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci set ffberlin-uplink.preset.current="no-tunnel"
+if [[ $(uci get ffberlin-uplink.preset.current) != "no-tunnel" ]]; then
   uci rename ffberlin-uplink.preset.current=previous
-  uci set ffberlin-uplink.preset.current='no-tunnel'
+  uci set ffberlin-uplink.preset.current="no-tunnel"
 fi
+# set set auth-type required for this uplink-type, e.g. for freifunk-wizard
+uci set ffberlin-uplink.uplink=settings
+uci set ffberlin-uplink.uplink.auth=none
+
 uci commit ffberlin-uplink
 
 . /lib/functions/guard.sh

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -4,9 +4,6 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-uci set network.ffuplink.default_type="no-tunnel"
-uci commit network.ffuplink
-
 uci delete network.ffuplink_dev
 uci set network.ffuplink_dev=device
 uci set network.ffuplink_dev.type=veth
@@ -14,6 +11,14 @@ uci set network.ffuplink_dev.name=ffuplink
 uci set network.ffuplink_dev.peer_name=ffuplink_wan
 # add ffuplink_dev to br-wan
 uci set network.wan.ifname="$(uci get network.wan.ifname) ffuplink_wan"
+
+prev_uplinktype=$(uci -q get network.ffuplink.default_type
+if ( -z $(prev_uplinktype) ); then
+  uci set network.ffuplink.default_type="no-tunnel"
+elif ( ! $(prev_uplinktype)="no-tunnel" ); then
+  uci set network.ffuplink.default_type="changed - $(prev_uplinktype), no-tunnel"
+fi
+
 uci commit network
 
 . /lib/functions/guard.sh

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+create_interface() {
+  uci set network.ffuplink=interface
+  uci set network.ffuplink.ifname=ffuplink
+  uci set network.ffuplink.proto=dhcp
+  uci set network.ffuplink.default_type="no-tunnel"
+}
+
 # always set correct masquerading, regardless of guard
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
@@ -12,11 +19,12 @@ uci set network.ffuplink_dev.peer_name=ffuplink_wan
 # add ffuplink_dev to br-wan
 uci set network.wan.ifname="$(uci get network.wan.ifname) ffuplink_wan"
 
-prev_uplinktype=$(uci -q get network.ffuplink.default_type
-if ( -z $(prev_uplinktype) ); then
+uci -q get network.ffuplink >/dev/null || create_interface
+prev_uplinktype=$(uci -q get network.ffuplink.default_type)
+if [ ${#prev_uplinktype} == 0 ]; then
   uci set network.ffuplink.default_type="no-tunnel"
-elif ( ! $(prev_uplinktype)="no-tunnel" ); then
-  uci set network.ffuplink.default_type="changed - $(prev_uplinktype), no-tunnel"
+elif [ ${prev_uplinktype} != "no-tunnel" ]; then
+  uci set network.ffuplink.default_type="changed - ${prev_uplinktype}, no-tunnel"
 fi
 
 uci commit network
@@ -24,8 +32,5 @@ uci commit network
 . /lib/functions/guard.sh
 guard "notunnel"
 
-uci delete network.ffuplink
-uci set network.ffuplink=interface
-uci set network.ffuplink.ifname=ffuplink
-uci set network.ffuplink.proto=dhcp
-uci commit network
+#uci delete network.ffuplink
+#uci commit network

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -1,15 +1,20 @@
 #!/bin/sh
 
-create_interface() {
-  uci set network.ffuplink=interface
-  uci set network.ffuplink.ifname=ffuplink
-  uci set network.ffuplink.proto=dhcp
-  uci set network.ffuplink.default_type="no-tunnel"
-}
+# set set auth-type required for this uplink-type, e.g. for freifunk-wizard
+uci set ffberlin-uplink.uplink=settings
+uci set ffberlin-uplink.uplink.auth=none
 
 # always set correct masquerading, regardless of guard
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
+
+uci -q get ffberlin-uplink.preset=settings || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci -q set ffberlin-uplink.preset.current="no-tunnel"
+if [[ $(uci get ffberlin-uplink.preset.current) != 'no-tunnel' ]]; then
+  uci rename ffberlin-uplink.preset.current=previous
+  uci set ffberlin-uplink.preset.current='no-tunnel'
+fi
+uci commit ffberlin-uplink
 
 uci delete network.ffuplink_dev
 uci set network.ffuplink_dev=device
@@ -18,19 +23,13 @@ uci set network.ffuplink_dev.name=ffuplink
 uci set network.ffuplink_dev.peer_name=ffuplink_wan
 # add ffuplink_dev to br-wan
 uci set network.wan.ifname="$(uci get network.wan.ifname) ffuplink_wan"
-
-uci -q get network.ffuplink >/dev/null || create_interface
-prev_uplinktype=$(uci -q get network.ffuplink.default_type)
-if [ ${#prev_uplinktype} == 0 ]; then
-  uci set network.ffuplink.default_type="no-tunnel"
-elif [ ${prev_uplinktype} != "no-tunnel" ]; then
-  uci set network.ffuplink.default_type="changed - ${prev_uplinktype}, no-tunnel"
-fi
-
-uci commit network
+uci commit network.ffuplink_dev
 
 . /lib/functions/guard.sh
 guard "notunnel"
 
-#uci delete network.ffuplink
-#uci commit network
+uci delete network.ffuplink
+uci set network.ffuplink=interface
+uci set network.ffuplink.ifname=ffuplink
+uci set network.ffuplink.proto=dhcp
+uci commit network

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -16,6 +16,9 @@ if [[ $(uci get ffberlin-uplink.preset.current) != 'no-tunnel' ]]; then
 fi
 uci commit ffberlin-uplink
 
+. /lib/functions/guard.sh
+guard "notunnel"
+
 uci delete network.ffuplink_dev
 uci set network.ffuplink_dev=device
 uci set network.ffuplink_dev.type=veth
@@ -24,9 +27,6 @@ uci set network.ffuplink_dev.peer_name=ffuplink_wan
 # add ffuplink_dev to br-wan
 uci set network.wan.ifname="$(uci get network.wan.ifname) ffuplink_wan"
 uci commit network.ffuplink_dev
-
-. /lib/functions/guard.sh
-guard "notunnel"
 
 uci delete network.ffuplink
 uci set network.ffuplink=interface

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -4,6 +4,9 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
+uci set network.ffuplink.default_type="no-tunnel"
+uci commit network.ffuplink
+
 uci delete network.ffuplink_dev
 uci set network.ffuplink_dev=device
 uci set network.ffuplink_dev.type=veth

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/Makefile
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-tunnelberlin-files
-PKG_VERSION:=0.0.2
+PKG_VERSION:=0.0.3
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
@@ -4,13 +4,14 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-uci -q get ffberlin-uplink.preset=settings || uci set ffberlin-uplink.preset=settings
-uci >/dev/null -q get ffberlin-uplink.preset.current || uci -q set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
-if [[ $(uci get ffberlin-uplink.preset.current) != 'tunnelberlin_openvpn' ]]; then
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
+uci >/dev/null -q get ffberlin-uplink.preset || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
+if [[ $(uci get ffberlin-uplink.preset.current) != '"tunnelberlin_openvpn"' ]]; then
   uci rename ffberlin-uplink.preset.current=previous
   uci set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
 fi
-uci commit network.ffuplink
+uci commit ffberlin-uplink
 
 . /lib/functions/guard.sh
 guard "tunnelberlin_openvpn"

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
@@ -4,7 +4,12 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-uci set network.ffuplink.default_type="tunnelberlin_openvpn"
+prev_uplinktype=$(uci -q get network.ffuplink.default_type
+if ( -z $(prev_uplinktype) ); then
+  uci set network.ffuplink.default_type="tunnelberlin_openvpn"
+elif ( ! $(prev_uplinktype)="tunnelberlin_openvpn" ); then
+  uci set network.ffuplink.default_type="changed - $(prev_uplinktype), tunnelberlin_openvpn"
+fi
 uci commit network.ffuplink
 
 . /lib/functions/guard.sh

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
@@ -4,11 +4,11 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-prev_uplinktype=$(uci -q get network.ffuplink.default_type
-if ( -z $(prev_uplinktype) ); then
+prev_uplinktype=$(uci -q get network.ffuplink.default_type)
+if [ ${#prev_uplinktype} == 0 ]; then
   uci set network.ffuplink.default_type="tunnelberlin_openvpn"
-elif ( ! $(prev_uplinktype)="tunnelberlin_openvpn" ); then
-  uci set network.ffuplink.default_type="changed - $(prev_uplinktype), tunnelberlin_openvpn"
+elif [ ${prev_uplinktype} != "tunnelberlin_openvpn" ]; then
+  uci set network.ffuplink.default_type="changed - ${prev_uplinktype}, tunnelberlin_openvpn"
 fi
 uci commit network.ffuplink
 

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
@@ -4,6 +4,9 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
+uci set network.ffuplink.default_type="tunnelberlin_openvpn"
+uci commit network.ffuplink
+
 . /lib/functions/guard.sh
 guard "tunnelberlin_openvpn"
 

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
@@ -4,11 +4,11 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-prev_uplinktype=$(uci -q get network.ffuplink.default_type)
-if [ ${#prev_uplinktype} == 0 ]; then
-  uci set network.ffuplink.default_type="tunnelberlin_openvpn"
-elif [ ${prev_uplinktype} != "tunnelberlin_openvpn" ]; then
-  uci set network.ffuplink.default_type="changed - ${prev_uplinktype}, tunnelberlin_openvpn"
+uci -q get ffberlin-uplink.preset=settings || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci -q set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
+if [[ $(uci get ffberlin-uplink.preset.current) != 'tunnelberlin_openvpn' ]]; then
+  uci rename ffberlin-uplink.preset.current=previous
+  uci set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
 fi
 uci commit network.ffuplink
 

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/Makefile
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-vpn03-files
-PKG_VERSION:=0.0.4
+PKG_VERSION:=0.0.5
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
@@ -4,13 +4,14 @@
 uci set firewall.zone_ffuplink.masq=0
 uci commit firewall
 
-uci -q get ffberlin-uplink.preset=settings || uci set ffberlin-uplink.preset=settings
-uci >/dev/null -q get ffberlin-uplink.preset.current || uci -q set ffberlin-uplink.preset.current="vpn03_openvpn"
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
+uci >/dev/null -q get ffberlin-uplink.preset || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci set ffberlin-uplink.preset.current="vpn03_openvpn"
 if [[ $(uci get ffberlin-uplink.preset.current) != 'vpn03_openvpn' ]]; then
   uci rename ffberlin-uplink.preset.current=previous
   uci set ffberlin-uplink.preset.current="vpn03_openvpn"
 fi
-uci commit network.ffuplink
+uci commit ffberlin-uplink
 
 . /lib/functions/guard.sh
 guard "vpn03_openvpn"

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
@@ -4,6 +4,9 @@
 uci set firewall.zone_ffuplink.masq=0
 uci commit firewall
 
+uci set network.ffuplink.default_type="vpn03_openvpn"
+uci commit network.ffuplink
+
 . /lib/functions/guard.sh
 guard "vpn03_openvpn"
 

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
@@ -4,11 +4,11 @@
 uci set firewall.zone_ffuplink.masq=0
 uci commit firewall
 
-prev_uplinktype=$(uci -q get network.ffuplink.default_type)
-if [ ${#prev_uplinktype} == 0 ]; then
-  uci set network.ffuplink.default_type="vpn03_openvpn"
-elif [ ${prev_uplinktype} != "vpn03_openvpn" ]; then
-  uci set network.ffuplink.default_type="changed - ${prev_uplinktype}, vpn03_openvpn"
+uci -q get ffberlin-uplink.preset=settings || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci -q set ffberlin-uplink.preset.current="vpn03_openvpn"
+if [[ $(uci get ffberlin-uplink.preset.current) != 'vpn03_openvpn' ]]; then
+  uci rename ffberlin-uplink.preset.current=previous
+  uci set ffberlin-uplink.preset.current="vpn03_openvpn"
 fi
 uci commit network.ffuplink
 

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
@@ -4,11 +4,11 @@
 uci set firewall.zone_ffuplink.masq=0
 uci commit firewall
 
-prev_uplinktype=$(uci -q get network.ffuplink.default_type
-if ( -z $(prev_uplinktype) ); then
+prev_uplinktype=$(uci -q get network.ffuplink.default_type)
+if [ ${#prev_uplinktype} == 0 ]; then
   uci set network.ffuplink.default_type="vpn03_openvpn"
-elif ( ! $(prev_uplinktype)="vpn03_openvpn" ); then
-  uci set network.ffuplink.default_type="changed - $(prev_uplinktype), vpn03_openvpn"
+elif [ ${prev_uplinktype} != "vpn03_openvpn" ]; then
+  uci set network.ffuplink.default_type="changed - ${prev_uplinktype}, vpn03_openvpn"
 fi
 uci commit network.ffuplink
 

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
@@ -4,7 +4,12 @@
 uci set firewall.zone_ffuplink.masq=0
 uci commit firewall
 
-uci set network.ffuplink.default_type="vpn03_openvpn"
+prev_uplinktype=$(uci -q get network.ffuplink.default_type
+if ( -z $(prev_uplinktype) ); then
+  uci set network.ffuplink.default_type="vpn03_openvpn"
+elif ( ! $(prev_uplinktype)="vpn03_openvpn" ); then
+  uci set network.ffuplink.default_type="changed - $(prev_uplinktype), vpn03_openvpn"
+fi
 uci commit network.ffuplink
 
 . /lib/functions/guard.sh

--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
-PKG_VERSION:=0.4.6
+PKG_VERSION:=0.4.7
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
-PKG_VERSION:=0.4.5
+PKG_VERSION:=0.4.6
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -321,6 +321,23 @@ r1_0_0_change_to_ffuplink() {
   config_foreach remove_routingpolicy rule
 }
 
+r1_0_0_update_preliminary_glinet_names() {
+  case `uci get system.led_wlan.sysfs` in
+    "gl_ar150:wlan")
+      log "correcting system.led_wlan.sysfs for GLinet AR150"
+      uci set system.led_wlan.sysfs="gl-ar150:wlan"
+      ;;
+    "gl_ar300:wlan")
+      log "correcting system.led_wlan.sysfs for GLinet AR300"
+      uci set system.led_wlan.sysfs="gl-ar300:wlan"
+      ;;
+    "domino:blue:wlan")
+      log "correcting system.led_wlan.sysfs for GLinet Domino"
+      uci set system.led_wlan.sysfs="gl-domino:blue:wlan"
+      ;;
+  esac
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -365,6 +382,7 @@ migrate () {
     r1_0_0_no_wan_restart
     r1_0_0_firewallzone_uplink
     r1_0_0_change_to_ffuplink
+    r1_0_0_update_preliminary_glinet_names
   fi
 
   # overwrite version with the new version

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -345,6 +345,9 @@ r1_0_0_upstream() {
   cp /rom/etc/inittab /etc/inittab
   cp /rom/etc/profile /etc/profile
   cp /rom/etc/hosts /etc/hosts
+  log " checking for user dnsmasq"
+  group_exists "dnsmasq" || group_add "dnsmasq" "453"
+  user_exists "dnsmasq" || user_add "dnsmasq" "453" "453"
 }
 
 migrate () {

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -338,6 +338,7 @@ r1_0_0_update_preliminary_glinet_names() {
 }
 
 r1_0_0_upstream() {
+  log "applying upstream changes / sync with upstream"
   grep -q "^kernel.core_pattern=" /etc/sysctl.conf || echo >>/etc/sysctl.conf "kernel.core_pattern=/tmp/%e.%t.%p.%s.core"
   sed -i '/^net.ipv4.tcp_ecn=0/d' /etc/sysctl.conf
   grep -q "^128" /etc/iproute2/rt_tables || echo >>/etc/iproute2/rt_tables "128	prelocal"

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -281,6 +281,17 @@ r1_0_0_change_to_ffuplink() {
       return 1
     fi
   }
+  remove_routingpolicy() {
+    local config=$1
+    case "$config" in
+      olsr_*_ffvpn_ipv4*) 
+        log "  network.$config"
+        uci delete network.$config
+        ;;
+      *) ;;
+    esac
+  }
+
   log "changing interface ffvpn to ffuplink"
   log " setting wan as bridge"
   uci set network.wan.type=bridge
@@ -304,6 +315,10 @@ r1_0_0_change_to_ffuplink() {
   reset_cb
   config_load olsrd
   config_foreach change_olsrd_dygw_ping_iface LoadPlugin
+  log " removing deprecated IP-rules"
+  reset_cb
+  config_load network
+  config_foreach remove_routingpolicy rule
 }
 
 migrate () {

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -337,6 +337,15 @@ r1_0_0_update_preliminary_glinet_names() {
   esac
 }
 
+r1_0_0_upstream() {
+  grep -q "^kernel.core_pattern=" /etc/sysctl.conf || echo >>/etc/sysctl.conf "kernel.core_pattern=/tmp/%e.%t.%p.%s.core"
+  sed -i '/^net.ipv4.tcp_ecn=0/d' /etc/sysctl.conf
+  grep -q "^128" /etc/iproute2/rt_tables || echo >>/etc/iproute2/rt_tables "128	prelocal"
+  cp /rom/etc/inittab /etc/inittab
+  cp /rom/etc/profile /etc/profile
+  cp /rom/etc/hosts /etc/hosts
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -382,6 +391,7 @@ migrate () {
     r1_0_0_firewallzone_uplink
     r1_0_0_change_to_ffuplink
     r1_0_0_update_preliminary_glinet_names
+    r1_0_0_upstream
   fi
 
   # overwrite version with the new version

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -350,6 +350,36 @@ r1_0_0_upstream() {
   user_exists "dnsmasq" || user_add "dnsmasq" "453" "453"
 }
 
+r1_0_0_set_uplinktype() {
+  log "storing used uplink-type"
+  log " migrating from Kathleen-release, assuming VPN03 as uplink-preset"
+  echo "" | uci import ffberlin-uplink
+  uci set ffberlin-uplink.preset=settings
+  uci set ffberlin-uplink.preset.current="vpn03_openvpn"
+}
+
+r1_0_1_set_uplinktype() {
+  uci >/dev/null -q get ffberlin-uplink.preset && return 0
+
+  log "storing used uplink-type for Hedy"
+  uci set ffberlin-uplink.preset=settings
+  uci set ffberlin-uplink.preset.current="unknown"
+  if [ "$(uci -q get network.ffuplink_dev.type)" = "veth" ]; then
+    uci set ffberlin-uplink.preset.current="no-tunnel"
+  else
+    case "$(uci -q get openvpn.ffuplink.remote)" in
+      \'vpn03.berlin.freifunk.net*)
+        uci set ffberlin-uplink.preset.current="vpn03_openvpn"
+        ;;
+      \'tunnel-gw.berlin.freifunk.net*)
+        uci set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
+        ;;
+    esac
+    fi
+  log " type set to $(uci get ffberlin-uplink.preset.current)"
+}
+
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -396,6 +426,11 @@ migrate () {
     r1_0_0_change_to_ffuplink
     r1_0_0_update_preliminary_glinet_names
     r1_0_0_upstream
+    r1_0_0_set_uplinktype
+  fi
+
+  if semverLT ${OLD_VERSION} "1.0.1"; then
+    r1_0_1_set_uplinktype
   fi
 
   # overwrite version with the new version

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -246,7 +246,6 @@ set_ipversion_olsrd6() {
 r1_0_0_vpn03_splitconfig() {
   log "changing guard-entry for VPN03 from openvpn to vpn03-openvpn (config-split for VPN03)"
   guard_rename openvpn vpn03_openvpn # to guard the current settings of package "freifunk-berlin-vpn03-files"
-  guard openvpn # to guard the current settings of package "freifunk-berlin-openvpn-files"
 }
 
 r1_0_0_no_wan_restart() {


### PR DESCRIPTION
This provides the migration steps to upgrade from Kathleen 0.3.0 to Hedy 1.0.0 and creates a Hedy 1.0.1.
Beside upgrading our settings, there is also a step "r1_0_0_upstream()" (https://github.com/freifunk-berlin/firmware-packages/commit/46ca9b5803df412ed595bef975a3e1c6f26e581b) which updates some files that are purely upstream and never touched by us.
With this PR we also get a UCI-value (ffberlin-uplink.preset.current) for the uplink-preset that was used last time. this can be used to determine, if the preset has been changed during the upgrade, to select the proper uplink-preset for the next time or an auto-upgrader.