### PR TITLE
Added the option ip4table and ip6table to the no-tunnel ffuplink interface

### DIFF
--- a/defaults/freifunk-berlin-openvpn-files/Makefile
+++ b/defaults/freifunk-berlin-openvpn-files/Makefile
@@ -3,8 +3,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-openvpn-files
-PKG_VERSION:=0.0.7
-PKG_RELEASE:=2
+PKG_VERSION:=0.0.8
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -40,8 +40,6 @@ define Package/freifunk-berlin-openvpn-files/install
 	$(CP) ./openvpn/ffvpn-up.sh $(1)/lib/freifunk
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
 	$(CP) ./openvpn/60-ffopenvpn $(1)/etc/hotplug.d/iface
-	$(INSTALL_DIR) $(1)/etc/config
-	$(CP) ./files/ffberlin-uplink $(1)/etc/config
 endef
 
 $(eval $(call BuildPackage,freifunk-berlin-openvpn-files))

--- a/defaults/freifunk-berlin-openvpn-files/files/ffberlin-uplink
+++ b/defaults/freifunk-berlin-openvpn-files/files/ffberlin-uplink
@@ -1,4 +1,0 @@
-
-config settings uplink
-        option auth 'x509'
-

--- a/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
+++ b/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# set set auth-type required for this uplink-type, e.g. for freifunk-wizard
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
+uci set ffberlin-uplink.uplink=settings
+uci set ffberlin-uplink.uplink.auth=x509
+uci commit ffberlin-uplink.uplink
+
 uci -q delete openvpn.custom_config
 uci -q delete openvpn.sample_server
 uci -q delete openvpn.sample_client

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-notunnel-files
-PKG_VERSION:=0.0.5
+PKG_VERSION:=0.0.6
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
@@ -40,8 +40,6 @@ define Package/$(PKG_NAME)/install
 	$(CP) ./uci-defaults/* $(1)/etc/uci-defaults
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
 	$(CP) ./files/60-ffuplink $(1)/etc/hotplug.d/iface
-	$(INSTALL_DIR) $(1)/etc/config
-	$(CP) ./files/ffberlin-uplink $(1)/etc/config
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/files/60-ffuplink
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/files/60-ffuplink
@@ -11,10 +11,17 @@ config_get sharenet settings sharenet
 
 if [ "$INTERFACE" = ffuplink ]; then
   if [ "$ACTION" = ifup ]; then
-    local gateway
+#
+# The routing table assignment for ffuplink is now set in 
+# /etc/config/network with the ip{4|6}table options.  The
+# previously used script is here as comments for documentation 
+# purposes only.  
+# Logging has been left in place for obvious reasons.
+#
+#    local gateway
     logger -t ff-userlog "ffuplink connection will be established"
-    network_get_gateway gateway wan
-    ip route add default via ${gateway} dev ffuplink table ffuplink
+#    network_get_gateway gateway wan
+#    ip route add default via ${gateway} dev ffuplink table ffuplink
     logger -t ff-userlog "ffuplink connection has been established"
   fi
   if [ "$ACTION" = ifdown ]; then
@@ -31,14 +38,17 @@ fi
 if [ "$ACTION" = ifup ]; then
   logger -t ff-userlog "WAN interface is up"
   if [ "$sharenet" = 1 ]; then
-    logger -t ff-vpn-hotplug "configuring ffuplink on WAN interface"
-    # Make sure OpenVPN connects only through WAN: set "local" option with WAN IP
-    local wanip
-    network_get_ipaddr wanip "wan"
+    logger -t ff-userlog "configuring ffuplink on WAN interface"
+#
+# The no-tunnel version only needs to have the ffuplink device activated
+# and therefore the following commented out commands are not needed.
+#
+#    local wanip
+#    network_get_ipaddr wanip "wan"
 #    ip link add ffuplink type veth peer name ffuplink_wan
 #    brctl addif br-wan ffuplink_wan
 #    ip link set up ffuplink_wan
-#    ifup ffuplink
+    ifup ffuplink
     exit
   fi
 fi

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/files/60-ffuplink
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/files/60-ffuplink
@@ -12,16 +12,9 @@ config_get sharenet settings sharenet
 if [ "$INTERFACE" = ffuplink ]; then
   if [ "$ACTION" = ifup ]; then
 #
-# The routing table assignment for ffuplink is now set in 
-# /etc/config/network with the ip{4|6}table options.  The
-# previously used script is here as comments for documentation 
-# purposes only.  
-# Logging has been left in place for obvious reasons.
+# The routing table assignment for ffuplink is set in 
+# /etc/config/network with the ip{4|6}table options.
 #
-#    local gateway
-    logger -t ff-userlog "ffuplink connection will be established"
-#    network_get_gateway gateway wan
-#    ip route add default via ${gateway} dev ffuplink table ffuplink
     logger -t ff-userlog "ffuplink connection has been established"
   fi
   if [ "$ACTION" = ifdown ]; then
@@ -31,23 +24,10 @@ fi
 
 [ "$INTERFACE" = wan ] || exit
 
-#config_load openvpn
-#local uci_vpn_enabled
-#config_get uci_vpn_enabled ffuplink enabled
-
 if [ "$ACTION" = ifup ]; then
   logger -t ff-userlog "WAN interface is up"
   if [ "$sharenet" = 1 ]; then
     logger -t ff-userlog "configuring ffuplink on WAN interface"
-#
-# The no-tunnel version only needs to have the ffuplink device activated
-# and therefore the following commented out commands are not needed.
-#
-#    local wanip
-#    network_get_ipaddr wanip "wan"
-#    ip link add ffuplink type veth peer name ffuplink_wan
-#    brctl addif br-wan ffuplink_wan
-#    ip link set up ffuplink_wan
     ifup ffuplink
     exit
   fi
@@ -61,4 +41,3 @@ if [ "$ACTION" = ifdown ]; then
     exit
   fi
 fi
-

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/files/ffberlin-uplink
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/files/ffberlin-uplink
@@ -1,4 +1,0 @@
-
-config settings uplink
-        option auth 'none'
-

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -34,6 +34,9 @@ uci delete network.ffuplink
 uci set network.ffuplink=interface
 uci set network.ffuplink.ifname=ffuplink
 uci set network.ffuplink.proto=dhcp
+# Put the resulting routing information from the dhcp request in the ffuplink table
+# instead of the default table.  This prevents the dhcp request for the ffuplink
+# interface from overwriting the routing table entries needed by br_wan.
 uci set network.ffuplink.ip4table=ffuplink
 uci set network.ffuplink.ip6table=ffuplink
 uci commit network

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -4,6 +4,23 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
+# create ffberlin-uplink file an fill with basic settings
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
+uci >/dev/null -q get ffberlin-uplink.preset || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci set ffberlin-uplink.preset.current="no-tunnel"
+if [[ $(uci get ffberlin-uplink.preset.current) != "no-tunnel" ]]; then
+  uci rename ffberlin-uplink.preset.current=previous
+  uci set ffberlin-uplink.preset.current="no-tunnel"
+fi
+# set set auth-type required for this uplink-type, e.g. for freifunk-wizard
+uci set ffberlin-uplink.uplink=settings
+uci set ffberlin-uplink.uplink.auth=none
+
+uci commit ffberlin-uplink
+
+. /lib/functions/guard.sh
+guard "notunnel"
+
 uci delete network.ffuplink_dev
 uci set network.ffuplink_dev=device
 uci set network.ffuplink_dev.type=veth
@@ -11,10 +28,7 @@ uci set network.ffuplink_dev.name=ffuplink
 uci set network.ffuplink_dev.peer_name=ffuplink_wan
 # add ffuplink_dev to br-wan
 uci set network.wan.ifname="$(uci get network.wan.ifname) ffuplink_wan"
-uci commit network
-
-. /lib/functions/guard.sh
-guard "notunnel"
+uci commit network.ffuplink_dev
 
 uci delete network.ffuplink
 uci set network.ffuplink=interface

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -34,4 +34,6 @@ uci delete network.ffuplink
 uci set network.ffuplink=interface
 uci set network.ffuplink.ifname=ffuplink
 uci set network.ffuplink.proto=dhcp
+uci set network.ffuplink.ip4table=ffuplink
+uci set network.ffuplink.ip6table=ffuplink
 uci commit network

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/Makefile
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-tunnelberlin-files
-PKG_VERSION:=0.0.2
+PKG_VERSION:=0.0.3
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
@@ -4,6 +4,15 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
+uci >/dev/null -q get ffberlin-uplink.preset || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
+if [[ $(uci get ffberlin-uplink.preset.current) != '"tunnelberlin_openvpn"' ]]; then
+  uci rename ffberlin-uplink.preset.current=previous
+  uci set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
+fi
+uci commit ffberlin-uplink
+
 . /lib/functions/guard.sh
 guard "tunnelberlin_openvpn"
 

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/Makefile
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-vpn03-files
-PKG_VERSION:=0.0.4
+PKG_VERSION:=0.0.5
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
@@ -4,6 +4,15 @@
 uci set firewall.zone_ffuplink.masq=0
 uci commit firewall
 
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
+uci >/dev/null -q get ffberlin-uplink.preset || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci set ffberlin-uplink.preset.current="vpn03_openvpn"
+if [[ $(uci get ffberlin-uplink.preset.current) != 'vpn03_openvpn' ]]; then
+  uci rename ffberlin-uplink.preset.current=previous
+  uci set ffberlin-uplink.preset.current="vpn03_openvpn"
+fi
+uci commit ffberlin-uplink
+
 . /lib/functions/guard.sh
 guard "vpn03_openvpn"
 

--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
-PKG_VERSION:=0.4.5
+PKG_VERSION:=0.4.7
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -246,7 +246,6 @@ set_ipversion_olsrd6() {
 r1_0_0_vpn03_splitconfig() {
   log "changing guard-entry for VPN03 from openvpn to vpn03-openvpn (config-split for VPN03)"
   guard_rename openvpn vpn03_openvpn # to guard the current settings of package "freifunk-berlin-vpn03-files"
-  guard openvpn # to guard the current settings of package "freifunk-berlin-openvpn-files"
 }
 
 r1_0_0_no_wan_restart() {
@@ -281,6 +280,17 @@ r1_0_0_change_to_ffuplink() {
       return 1
     fi
   }
+  remove_routingpolicy() {
+    local config=$1
+    case "$config" in
+      olsr_*_ffvpn_ipv4*) 
+        log "  network.$config"
+        uci delete network.$config
+        ;;
+      *) ;;
+    esac
+  }
+
   log "changing interface ffvpn to ffuplink"
   log " setting wan as bridge"
   uci set network.wan.type=bridge
@@ -304,7 +314,71 @@ r1_0_0_change_to_ffuplink() {
   reset_cb
   config_load olsrd
   config_foreach change_olsrd_dygw_ping_iface LoadPlugin
+  log " removing deprecated IP-rules"
+  reset_cb
+  config_load network
+  config_foreach remove_routingpolicy rule
 }
+
+r1_0_0_update_preliminary_glinet_names() {
+  case `uci get system.led_wlan.sysfs` in
+    "gl_ar150:wlan")
+      log "correcting system.led_wlan.sysfs for GLinet AR150"
+      uci set system.led_wlan.sysfs="gl-ar150:wlan"
+      ;;
+    "gl_ar300:wlan")
+      log "correcting system.led_wlan.sysfs for GLinet AR300"
+      uci set system.led_wlan.sysfs="gl-ar300:wlan"
+      ;;
+    "domino:blue:wlan")
+      log "correcting system.led_wlan.sysfs for GLinet Domino"
+      uci set system.led_wlan.sysfs="gl-domino:blue:wlan"
+      ;;
+  esac
+}
+
+r1_0_0_upstream() {
+  log "applying upstream changes / sync with upstream"
+  grep -q "^kernel.core_pattern=" /etc/sysctl.conf || echo >>/etc/sysctl.conf "kernel.core_pattern=/tmp/%e.%t.%p.%s.core"
+  sed -i '/^net.ipv4.tcp_ecn=0/d' /etc/sysctl.conf
+  grep -q "^128" /etc/iproute2/rt_tables || echo >>/etc/iproute2/rt_tables "128	prelocal"
+  cp /rom/etc/inittab /etc/inittab
+  cp /rom/etc/profile /etc/profile
+  cp /rom/etc/hosts /etc/hosts
+  log " checking for user dnsmasq"
+  group_exists "dnsmasq" || group_add "dnsmasq" "453"
+  user_exists "dnsmasq" || user_add "dnsmasq" "453" "453"
+}
+
+r1_0_0_set_uplinktype() {
+  log "storing used uplink-type"
+  log " migrating from Kathleen-release, assuming VPN03 as uplink-preset"
+  echo "" | uci import ffberlin-uplink
+  uci set ffberlin-uplink.preset=settings
+  uci set ffberlin-uplink.preset.current="vpn03_openvpn"
+}
+
+r1_0_1_set_uplinktype() {
+  uci >/dev/null -q get ffberlin-uplink.preset && return 0
+
+  log "storing used uplink-type for Hedy"
+  uci set ffberlin-uplink.preset=settings
+  uci set ffberlin-uplink.preset.current="unknown"
+  if [ "$(uci -q get network.ffuplink_dev.type)" = "veth" ]; then
+    uci set ffberlin-uplink.preset.current="no-tunnel"
+  else
+    case "$(uci -q get openvpn.ffuplink.remote)" in
+      \'vpn03.berlin.freifunk.net*)
+        uci set ffberlin-uplink.preset.current="vpn03_openvpn"
+        ;;
+      \'tunnel-gw.berlin.freifunk.net*)
+        uci set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
+        ;;
+    esac
+    fi
+  log " type set to $(uci get ffberlin-uplink.preset.current)"
+}
+
 
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
@@ -350,6 +424,13 @@ migrate () {
     r1_0_0_no_wan_restart
     r1_0_0_firewallzone_uplink
     r1_0_0_change_to_ffuplink
+    r1_0_0_update_preliminary_glinet_names
+    r1_0_0_upstream
+    r1_0_0_set_uplinktype
+  fi
+
+  if semverLT ${OLD_VERSION} "1.0.1"; then
+    r1_0_1_set_uplinktype
   fi
 
   # overwrite version with the new version


### PR DESCRIPTION
The problem is that the br-wan and ffuplink interfaces both request ip addresses via DHCP.  The second one to come up overwrites the default gw of the other.  This can lead to inconsistencies. 

This is the result of the discussion [#561](/freifunk-berlin/firmware/issues/561)
