### PR TITLE
Addon bbbdigger - An automatic configuration package for the bbbdigger

### DIFF
--- a/addons/bbbdigger/Makefile
+++ b/addons/bbbdigger/Makefile
@@ -32,13 +32,6 @@ define Package/bbbdigger/description
   Freifunk Berlin configuration of tunneldigger to connect to and mesh with the Berlin Backbone
 endef
 
-define Download/ubnt_mibs
-	URL_FILE:=ubnt-mib.zip
-	URL:=https://www.ubnt.com/downloads/firmwares/airos-ubnt-mib/
-	MD5SUM:=7e7dff89b99e51336c09c4e4dad53287
-	FILE:=$(UBIQUITI_MIBS_REL)
-endef
-
 define Build/Prepare
 endef
 

--- a/addons/bbbdigger/Makefile
+++ b/addons/bbbdigger/Makefile
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2016 Freifunk Berlin
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bbbdigger
+PKG_VERSION:=0.0.1
+PKG_RELEASE:=0
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/bbbdigger/default
+  SECTION:=freifunk-berlin
+  CATEGORY:=freifunk-berlin
+  URL:=http://github.com/freifunk-berlin/packages_berlin
+  PKGARCH:=all
+endef
+
+define Package/bbbdigger
+  $(call Package/bbbdigger/default)
+  TITLE:=A Tunneldigger (l2tp) based VPN connection to mesh with the Berlin Backbone
+  DEPENDS:=+tunneldigger
+endef
+
+define Package/bbbdigger/description
+  Freifunk Berlin configuration of tunneldigger to connect to and mesh with the Berlin Backbone
+endef
+
+define Download/ubnt_mibs
+	URL_FILE:=ubnt-mib.zip
+	URL:=https://www.ubnt.com/downloads/firmwares/airos-ubnt-mib/
+	MD5SUM:=7e7dff89b99e51336c09c4e4dad53287
+	FILE:=$(UBIQUITI_MIBS_REL)
+endef
+
+define Build/Prepare
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/bbbdigger/install
+	$(INSTALL_DIR) $(1)/tmp
+	$(INSTALL_BIN) ./files/postinst.sh $(1)/tmp/bbbdigger_postinst.sh
+endef
+
+define Package/bbbdigger/postinst
+#!/bin/sh
+$${IPKG_INSTROOT}/tmp/bbbdigger_postinst.sh
+endef
+
+$(eval $(call BuildPackage,bbbdigger))

--- a/addons/bbbdigger/files/postinst.sh
+++ b/addons/bbbdigger/files/postinst.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+# clear out all bbbdigger settings
+
+# tunneldigger
+uci del tunneldigger.bbbdigger
+
+# network
+uci del network.interface.bbbdigger
+uci del network.device.bbbdigger
+# create bbbdigger setup
+
+# tunneldigger
+uci set tunneldigger.bbbdigger=broker
+uci set tunneldigger.bbbdigger.enabled=1
+uci add_list tunneldigger.bbbdigger.address='77.87.51.51:8942'
+uci set tunneldigger.bbbdigger.uuid=$UUID
+uci set tunneldigger.bbbdigger.interface=bbbvpn
+uci set tunneldigger.bbbdigger.broker_selection=usage
+

--- a/addons/bbbdigger/files/postinst.sh
+++ b/addons/bbbdigger/files/postinst.sh
@@ -80,3 +80,5 @@ uci set olsrd.@Interface[-1].Mode=ether
 #uci changes
 
 uci commit
+reload_config
+/etc/init.d/tunneldigger restart

--- a/addons/bbbdigger/files/postinst.sh
+++ b/addons/bbbdigger/files/postinst.sh
@@ -2,21 +2,73 @@
 
 . /lib/functions.sh
 
-# clear out all bbbdigger settings
+BBBDIGGER_SERV='77.87.51.51:8942'
 
-# tunneldigger
-uci del tunneldigger.bbbdigger
+# tunneldigger UUID (and MAC) generation, if there isn't one already
+UUID=$(uci get tunneldigger.bbbdigger.uuid)
+if [ $? -eq 1 ]; then
+  UUID="b6"
+  for byte in 2 3 4 5 6; do
+    UUID=$UUID`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
+  done
 
-# network
-uci del network.interface.bbbdigger
-uci del network.device.bbbdigger
-# create bbbdigger setup
+fi
+echo $UUID
 
-# tunneldigger
+# remove all existing bbbdigger refences from the config files
+uci delete tunneldigger.bbbdigger
+uci delete network.bbbdigger
+uci delete network.bbbdigger_dev
+uci delete network.olsr_tunnel_bbbdigger_ipv4
+uci delete network.olsr_default_bbbdigger_ipv4
+uci delete network.olsr_default_unreachable_bbbdigger_ipv4
+ZONE=$(uci show firewall.zone_freifunk.network | cut -d \' -f 2 | sed 's/ *bbbdigger *//g')
+uci set firewall.zone_freifunk.network="${ZONE}"
+uci delete $(uci show olsrd | grep bbbdigger | cut -d = -f 1)
+
+#uci changes
+
+# tunneldigger setup
 uci set tunneldigger.bbbdigger=broker
-uci set tunneldigger.bbbdigger.enabled=1
-uci add_list tunneldigger.bbbdigger.address='77.87.51.51:8942'
+uci add_list tunneldigger.bbbdigger.address=$BBBDIGGER_SERV
 uci set tunneldigger.bbbdigger.uuid=$UUID
 uci set tunneldigger.bbbdigger.interface=bbbvpn
 uci set tunneldigger.bbbdigger.broker_selection=usage
+uci set tunneldigger.bbbdigger.enabled=1
 
+# network setup
+uci set network.bbbdigger_dev=device
+uci set network.bbbdigger_dev.macaddr=$UUID
+uci set network.bbbdigger_dev.name=bbbdigger
+uci set network.bbbdigger=interface
+uci set network.bbbdigger.proto=dhcp
+uci set network.bbbdigger.ifname=bbbdigger
+
+uci set network.olsr_tunnel_bbbdigger_ipv4=rule
+uci set network.olsr_tunnel_bbbdigger_ipv4.lookup=olsr-tunnel
+uci set network.olsr_tunnel_bbbdigger_ipv4.priority=19999
+uci set network.olsr_tunnel_bbbdigger_ipv4.in=bbbdigger
+
+uci set network.olsr_default_bbbdigger_ipv4=rule
+uci set network.olsr_default_bbbdigger_ipv4.lookup=olsr-default
+uci set network.olsr_default_bbbdigger_ipv4.priority=20000
+uci set network.olsr_default_bbbdigger_ipv4.in=bbbdigger
+
+uci set network.olsr_default_unreachable_bbbdigger_ipv4=rule
+uci set network.olsr_default_unreachable_bbbdigger_ipv4.action=unreachable
+uci set network.olsr_default_unreachable_bbbdigger_ipv4.priority=20001
+uci set network.olsr_default_unreachable_bbbdigger_ipv4.in=bbbdigger
+ 
+# firewall setup
+ZONE="$ZONE bbbdigger"
+uci set firewall.zone_freifunk.network="${ZONE}"
+
+# olsr setup
+uci add olsrd Interface
+uci set olsrd.@Interface[-1].ignore=0
+uci set olsrd.@Interface[-1].interface=bbbdigger
+uci set olsrd.@Interface[-1].Mode=ether
+
+#uci changes
+
+uci commit

--- a/addons/collectd-addons/Makefile
+++ b/addons/collectd-addons/Makefile
@@ -8,10 +8,10 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=collectd-addons
-PKG_VERSION:=0.0.2
-PKG_RELEASE:=2
+PKG_VERSION:=0.0.3
+PKG_RELEASE:=1
 
-UBIQUITI_MIBS_REL=ubnt-mibs_20160803.zip
+UBIQUITI_MIBS_REL=ubnt-mibs_20171003.zip
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -45,9 +45,9 @@ define Package/collectd-dnsmasq-addon/description
 endef
 
 define Download/ubnt_mibs
-	URL_FILE:=UBNT-MIBs.zip
-	URL:=https://help.ubnt.com/hc/en-us/article_attachments/203306028/
-	MD5SUM:=92087a11d75a94c7cfdb81f730642614
+	URL_FILE:=ubnt-mib.zip
+	URL:=https://www.ubnt.com/downloads/firmwares/airos-ubnt-mib/
+	MD5SUM:=7e7dff89b99e51336c09c4e4dad53287
 	FILE:=$(UBIQUITI_MIBS_REL)
 endef
 

--- a/defaults/freifunk-berlin-openvpn-files/Makefile
+++ b/defaults/freifunk-berlin-openvpn-files/Makefile
@@ -40,8 +40,6 @@ define Package/freifunk-berlin-openvpn-files/install
 	$(CP) ./openvpn/ffvpn-up.sh $(1)/lib/freifunk
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
 	$(CP) ./openvpn/60-ffopenvpn $(1)/etc/hotplug.d/iface
-	$(INSTALL_DIR) $(1)/etc/config
-	$(CP) ./files/ffberlin-uplink $(1)/etc/config
 endef
 
 $(eval $(call BuildPackage,freifunk-berlin-openvpn-files))

--- a/defaults/freifunk-berlin-openvpn-files/Makefile
+++ b/defaults/freifunk-berlin-openvpn-files/Makefile
@@ -3,8 +3,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-openvpn-files
-PKG_VERSION:=0.0.7
-PKG_RELEASE:=2
+PKG_VERSION:=0.0.8
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/defaults/freifunk-berlin-openvpn-files/files/ffberlin-uplink
+++ b/defaults/freifunk-berlin-openvpn-files/files/ffberlin-uplink
@@ -1,4 +1,0 @@
-
-config settings uplink
-        option auth 'x509'
-

--- a/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
+++ b/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+# set set auth-type required for this uplink-type, e.g. for freifunk-wizard
+uci set ffberlin-uplink.uplink=settings
+uci set ffberlin-uplink.uplink.auth=x509
+
 uci -q delete openvpn.custom_config
 uci -q delete openvpn.sample_server
 uci -q delete openvpn.sample_client

--- a/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
+++ b/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
@@ -1,8 +1,10 @@
 #!/bin/sh
 
 # set set auth-type required for this uplink-type, e.g. for freifunk-wizard
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
 uci set ffberlin-uplink.uplink=settings
 uci set ffberlin-uplink.uplink.auth=x509
+uci commit ffberlin-uplink.uplink
 
 uci -q delete openvpn.custom_config
 uci -q delete openvpn.sample_server

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
@@ -40,8 +40,6 @@ define Package/$(PKG_NAME)/install
 	$(CP) ./uci-defaults/* $(1)/etc/uci-defaults
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
 	$(CP) ./files/60-ffuplink $(1)/etc/hotplug.d/iface
-	$(INSTALL_DIR) $(1)/etc/config
-	$(CP) ./files/ffberlin-uplink $(1)/etc/config
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-notunnel-files
-PKG_VERSION:=0.0.5
+PKG_VERSION:=0.0.6
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/files/ffberlin-uplink
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/files/ffberlin-uplink
@@ -1,4 +1,0 @@
-
-config settings uplink
-        option auth 'none'
-

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -1,19 +1,21 @@
 #!/bin/sh
 
-# set set auth-type required for this uplink-type, e.g. for freifunk-wizard
-uci set ffberlin-uplink.uplink=settings
-uci set ffberlin-uplink.uplink.auth=none
-
 # always set correct masquerading, regardless of guard
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-uci -q get ffberlin-uplink.preset=settings || uci set ffberlin-uplink.preset=settings
-uci >/dev/null -q get ffberlin-uplink.preset.current || uci -q set ffberlin-uplink.preset.current="no-tunnel"
-if [[ $(uci get ffberlin-uplink.preset.current) != 'no-tunnel' ]]; then
+# create ffberlin-uplink file an fill with basic settings
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
+uci >/dev/null -q get ffberlin-uplink.preset || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci set ffberlin-uplink.preset.current="no-tunnel"
+if [[ $(uci get ffberlin-uplink.preset.current) != "no-tunnel" ]]; then
   uci rename ffberlin-uplink.preset.current=previous
-  uci set ffberlin-uplink.preset.current='no-tunnel'
+  uci set ffberlin-uplink.preset.current="no-tunnel"
 fi
+# set set auth-type required for this uplink-type, e.g. for freifunk-wizard
+uci set ffberlin-uplink.uplink=settings
+uci set ffberlin-uplink.uplink.auth=none
+
 uci commit ffberlin-uplink
 
 . /lib/functions/guard.sh

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -4,9 +4,6 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-uci set network.ffuplink.default_type="no-tunnel"
-uci commit network.ffuplink
-
 uci delete network.ffuplink_dev
 uci set network.ffuplink_dev=device
 uci set network.ffuplink_dev.type=veth
@@ -14,6 +11,14 @@ uci set network.ffuplink_dev.name=ffuplink
 uci set network.ffuplink_dev.peer_name=ffuplink_wan
 # add ffuplink_dev to br-wan
 uci set network.wan.ifname="$(uci get network.wan.ifname) ffuplink_wan"
+
+prev_uplinktype=$(uci -q get network.ffuplink.default_type
+if ( -z $(prev_uplinktype) ); then
+  uci set network.ffuplink.default_type="no-tunnel"
+elif ( ! $(prev_uplinktype)="no-tunnel" ); then
+  uci set network.ffuplink.default_type="changed - $(prev_uplinktype), no-tunnel"
+fi
+
 uci commit network
 
 . /lib/functions/guard.sh

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+create_interface() {
+  uci set network.ffuplink=interface
+  uci set network.ffuplink.ifname=ffuplink
+  uci set network.ffuplink.proto=dhcp
+  uci set network.ffuplink.default_type="no-tunnel"
+}
+
 # always set correct masquerading, regardless of guard
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
@@ -12,11 +19,12 @@ uci set network.ffuplink_dev.peer_name=ffuplink_wan
 # add ffuplink_dev to br-wan
 uci set network.wan.ifname="$(uci get network.wan.ifname) ffuplink_wan"
 
-prev_uplinktype=$(uci -q get network.ffuplink.default_type
-if ( -z $(prev_uplinktype) ); then
+uci -q get network.ffuplink >/dev/null || create_interface
+prev_uplinktype=$(uci -q get network.ffuplink.default_type)
+if [ ${#prev_uplinktype} == 0 ]; then
   uci set network.ffuplink.default_type="no-tunnel"
-elif ( ! $(prev_uplinktype)="no-tunnel" ); then
-  uci set network.ffuplink.default_type="changed - $(prev_uplinktype), no-tunnel"
+elif [ ${prev_uplinktype} != "no-tunnel" ]; then
+  uci set network.ffuplink.default_type="changed - ${prev_uplinktype}, no-tunnel"
 fi
 
 uci commit network
@@ -24,8 +32,5 @@ uci commit network
 . /lib/functions/guard.sh
 guard "notunnel"
 
-uci delete network.ffuplink
-uci set network.ffuplink=interface
-uci set network.ffuplink.ifname=ffuplink
-uci set network.ffuplink.proto=dhcp
-uci commit network
+#uci delete network.ffuplink
+#uci commit network

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -1,15 +1,20 @@
 #!/bin/sh
 
-create_interface() {
-  uci set network.ffuplink=interface
-  uci set network.ffuplink.ifname=ffuplink
-  uci set network.ffuplink.proto=dhcp
-  uci set network.ffuplink.default_type="no-tunnel"
-}
+# set set auth-type required for this uplink-type, e.g. for freifunk-wizard
+uci set ffberlin-uplink.uplink=settings
+uci set ffberlin-uplink.uplink.auth=none
 
 # always set correct masquerading, regardless of guard
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
+
+uci -q get ffberlin-uplink.preset=settings || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci -q set ffberlin-uplink.preset.current="no-tunnel"
+if [[ $(uci get ffberlin-uplink.preset.current) != 'no-tunnel' ]]; then
+  uci rename ffberlin-uplink.preset.current=previous
+  uci set ffberlin-uplink.preset.current='no-tunnel'
+fi
+uci commit ffberlin-uplink
 
 uci delete network.ffuplink_dev
 uci set network.ffuplink_dev=device
@@ -18,19 +23,13 @@ uci set network.ffuplink_dev.name=ffuplink
 uci set network.ffuplink_dev.peer_name=ffuplink_wan
 # add ffuplink_dev to br-wan
 uci set network.wan.ifname="$(uci get network.wan.ifname) ffuplink_wan"
-
-uci -q get network.ffuplink >/dev/null || create_interface
-prev_uplinktype=$(uci -q get network.ffuplink.default_type)
-if [ ${#prev_uplinktype} == 0 ]; then
-  uci set network.ffuplink.default_type="no-tunnel"
-elif [ ${prev_uplinktype} != "no-tunnel" ]; then
-  uci set network.ffuplink.default_type="changed - ${prev_uplinktype}, no-tunnel"
-fi
-
-uci commit network
+uci commit network.ffuplink_dev
 
 . /lib/functions/guard.sh
 guard "notunnel"
 
-#uci delete network.ffuplink
-#uci commit network
+uci delete network.ffuplink
+uci set network.ffuplink=interface
+uci set network.ffuplink.ifname=ffuplink
+uci set network.ffuplink.proto=dhcp
+uci commit network

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -16,6 +16,9 @@ if [[ $(uci get ffberlin-uplink.preset.current) != 'no-tunnel' ]]; then
 fi
 uci commit ffberlin-uplink
 
+. /lib/functions/guard.sh
+guard "notunnel"
+
 uci delete network.ffuplink_dev
 uci set network.ffuplink_dev=device
 uci set network.ffuplink_dev.type=veth
@@ -24,9 +27,6 @@ uci set network.ffuplink_dev.peer_name=ffuplink_wan
 # add ffuplink_dev to br-wan
 uci set network.wan.ifname="$(uci get network.wan.ifname) ffuplink_wan"
 uci commit network.ffuplink_dev
-
-. /lib/functions/guard.sh
-guard "notunnel"
 
 uci delete network.ffuplink
 uci set network.ffuplink=interface

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -4,6 +4,9 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
+uci set network.ffuplink.default_type="no-tunnel"
+uci commit network.ffuplink
+
 uci delete network.ffuplink_dev
 uci set network.ffuplink_dev=device
 uci set network.ffuplink_dev.type=veth

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -4,23 +4,6 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-# create ffberlin-uplink file an fill with basic settings
-uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
-uci >/dev/null -q get ffberlin-uplink.preset || uci set ffberlin-uplink.preset=settings
-uci >/dev/null -q get ffberlin-uplink.preset.current || uci set ffberlin-uplink.preset.current="no-tunnel"
-if [[ $(uci get ffberlin-uplink.preset.current) != "no-tunnel" ]]; then
-  uci rename ffberlin-uplink.preset.current=previous
-  uci set ffberlin-uplink.preset.current="no-tunnel"
-fi
-# set set auth-type required for this uplink-type, e.g. for freifunk-wizard
-uci set ffberlin-uplink.uplink=settings
-uci set ffberlin-uplink.uplink.auth=none
-
-uci commit ffberlin-uplink
-
-. /lib/functions/guard.sh
-guard "notunnel"
-
 uci delete network.ffuplink_dev
 uci set network.ffuplink_dev=device
 uci set network.ffuplink_dev.type=veth
@@ -28,10 +11,15 @@ uci set network.ffuplink_dev.name=ffuplink
 uci set network.ffuplink_dev.peer_name=ffuplink_wan
 # add ffuplink_dev to br-wan
 uci set network.wan.ifname="$(uci get network.wan.ifname) ffuplink_wan"
-uci commit network.ffuplink_dev
+uci commit network
+
+. /lib/functions/guard.sh
+guard "notunnel"
 
 uci delete network.ffuplink
 uci set network.ffuplink=interface
 uci set network.ffuplink.ifname=ffuplink
 uci set network.ffuplink.proto=dhcp
+uci set network.ffuplink.ip4table=ffuplink
+uci set network.ffuplink.ip6table=ffuplink
 uci commit network

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/Makefile
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-tunnelberlin-files
-PKG_VERSION:=0.0.2
+PKG_VERSION:=0.0.3
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
@@ -4,13 +4,14 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-uci -q get ffberlin-uplink.preset=settings || uci set ffberlin-uplink.preset=settings
-uci >/dev/null -q get ffberlin-uplink.preset.current || uci -q set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
-if [[ $(uci get ffberlin-uplink.preset.current) != 'tunnelberlin_openvpn' ]]; then
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
+uci >/dev/null -q get ffberlin-uplink.preset || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
+if [[ $(uci get ffberlin-uplink.preset.current) != '"tunnelberlin_openvpn"' ]]; then
   uci rename ffberlin-uplink.preset.current=previous
   uci set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
 fi
-uci commit network.ffuplink
+uci commit ffberlin-uplink
 
 . /lib/functions/guard.sh
 guard "tunnelberlin_openvpn"

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
@@ -4,7 +4,12 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-uci set network.ffuplink.default_type="tunnelberlin_openvpn"
+prev_uplinktype=$(uci -q get network.ffuplink.default_type
+if ( -z $(prev_uplinktype) ); then
+  uci set network.ffuplink.default_type="tunnelberlin_openvpn"
+elif ( ! $(prev_uplinktype)="tunnelberlin_openvpn" ); then
+  uci set network.ffuplink.default_type="changed - $(prev_uplinktype), tunnelberlin_openvpn"
+fi
 uci commit network.ffuplink
 
 . /lib/functions/guard.sh

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
@@ -4,11 +4,11 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-prev_uplinktype=$(uci -q get network.ffuplink.default_type
-if ( -z $(prev_uplinktype) ); then
+prev_uplinktype=$(uci -q get network.ffuplink.default_type)
+if [ ${#prev_uplinktype} == 0 ]; then
   uci set network.ffuplink.default_type="tunnelberlin_openvpn"
-elif ( ! $(prev_uplinktype)="tunnelberlin_openvpn" ); then
-  uci set network.ffuplink.default_type="changed - $(prev_uplinktype), tunnelberlin_openvpn"
+elif [ ${prev_uplinktype} != "tunnelberlin_openvpn" ]; then
+  uci set network.ffuplink.default_type="changed - ${prev_uplinktype}, tunnelberlin_openvpn"
 fi
 uci commit network.ffuplink
 

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
@@ -4,6 +4,9 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
+uci set network.ffuplink.default_type="tunnelberlin_openvpn"
+uci commit network.ffuplink
+
 . /lib/functions/guard.sh
 guard "tunnelberlin_openvpn"
 

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
@@ -4,11 +4,11 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-prev_uplinktype=$(uci -q get network.ffuplink.default_type)
-if [ ${#prev_uplinktype} == 0 ]; then
-  uci set network.ffuplink.default_type="tunnelberlin_openvpn"
-elif [ ${prev_uplinktype} != "tunnelberlin_openvpn" ]; then
-  uci set network.ffuplink.default_type="changed - ${prev_uplinktype}, tunnelberlin_openvpn"
+uci -q get ffberlin-uplink.preset=settings || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci -q set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
+if [[ $(uci get ffberlin-uplink.preset.current) != 'tunnelberlin_openvpn' ]]; then
+  uci rename ffberlin-uplink.preset.current=previous
+  uci set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
 fi
 uci commit network.ffuplink
 

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/Makefile
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-vpn03-files
-PKG_VERSION:=0.0.4
+PKG_VERSION:=0.0.5
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
@@ -4,13 +4,14 @@
 uci set firewall.zone_ffuplink.masq=0
 uci commit firewall
 
-uci -q get ffberlin-uplink.preset=settings || uci set ffberlin-uplink.preset=settings
-uci >/dev/null -q get ffberlin-uplink.preset.current || uci -q set ffberlin-uplink.preset.current="vpn03_openvpn"
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
+uci >/dev/null -q get ffberlin-uplink.preset || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci set ffberlin-uplink.preset.current="vpn03_openvpn"
 if [[ $(uci get ffberlin-uplink.preset.current) != 'vpn03_openvpn' ]]; then
   uci rename ffberlin-uplink.preset.current=previous
   uci set ffberlin-uplink.preset.current="vpn03_openvpn"
 fi
-uci commit network.ffuplink
+uci commit ffberlin-uplink
 
 . /lib/functions/guard.sh
 guard "vpn03_openvpn"

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
@@ -4,6 +4,9 @@
 uci set firewall.zone_ffuplink.masq=0
 uci commit firewall
 
+uci set network.ffuplink.default_type="vpn03_openvpn"
+uci commit network.ffuplink
+
 . /lib/functions/guard.sh
 guard "vpn03_openvpn"
 

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
@@ -4,11 +4,11 @@
 uci set firewall.zone_ffuplink.masq=0
 uci commit firewall
 
-prev_uplinktype=$(uci -q get network.ffuplink.default_type)
-if [ ${#prev_uplinktype} == 0 ]; then
-  uci set network.ffuplink.default_type="vpn03_openvpn"
-elif [ ${prev_uplinktype} != "vpn03_openvpn" ]; then
-  uci set network.ffuplink.default_type="changed - ${prev_uplinktype}, vpn03_openvpn"
+uci -q get ffberlin-uplink.preset=settings || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci -q set ffberlin-uplink.preset.current="vpn03_openvpn"
+if [[ $(uci get ffberlin-uplink.preset.current) != 'vpn03_openvpn' ]]; then
+  uci rename ffberlin-uplink.preset.current=previous
+  uci set ffberlin-uplink.preset.current="vpn03_openvpn"
 fi
 uci commit network.ffuplink
 

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
@@ -4,11 +4,11 @@
 uci set firewall.zone_ffuplink.masq=0
 uci commit firewall
 
-prev_uplinktype=$(uci -q get network.ffuplink.default_type
-if ( -z $(prev_uplinktype) ); then
+prev_uplinktype=$(uci -q get network.ffuplink.default_type)
+if [ ${#prev_uplinktype} == 0 ]; then
   uci set network.ffuplink.default_type="vpn03_openvpn"
-elif ( ! $(prev_uplinktype)="vpn03_openvpn" ); then
-  uci set network.ffuplink.default_type="changed - $(prev_uplinktype), vpn03_openvpn"
+elif [ ${prev_uplinktype} != "vpn03_openvpn" ]; then
+  uci set network.ffuplink.default_type="changed - ${prev_uplinktype}, vpn03_openvpn"
 fi
 uci commit network.ffuplink
 

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
@@ -4,7 +4,12 @@
 uci set firewall.zone_ffuplink.masq=0
 uci commit firewall
 
-uci set network.ffuplink.default_type="vpn03_openvpn"
+prev_uplinktype=$(uci -q get network.ffuplink.default_type
+if ( -z $(prev_uplinktype) ); then
+  uci set network.ffuplink.default_type="vpn03_openvpn"
+elif ( ! $(prev_uplinktype)="vpn03_openvpn" ); then
+  uci set network.ffuplink.default_type="changed - $(prev_uplinktype), vpn03_openvpn"
+fi
 uci commit network.ffuplink
 
 . /lib/functions/guard.sh

--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
-PKG_VERSION:=0.4.6
+PKG_VERSION:=0.4.7
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
-PKG_VERSION:=0.4.5
+PKG_VERSION:=0.4.6
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -321,6 +321,23 @@ r1_0_0_change_to_ffuplink() {
   config_foreach remove_routingpolicy rule
 }
 
+r1_0_0_update_preliminary_glinet_names() {
+  case `uci get system.led_wlan.sysfs` in
+    "gl_ar150:wlan")
+      log "correcting system.led_wlan.sysfs for GLinet AR150"
+      uci set system.led_wlan.sysfs="gl-ar150:wlan"
+      ;;
+    "gl_ar300:wlan")
+      log "correcting system.led_wlan.sysfs for GLinet AR300"
+      uci set system.led_wlan.sysfs="gl-ar300:wlan"
+      ;;
+    "domino:blue:wlan")
+      log "correcting system.led_wlan.sysfs for GLinet Domino"
+      uci set system.led_wlan.sysfs="gl-domino:blue:wlan"
+      ;;
+  esac
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -365,6 +382,7 @@ migrate () {
     r1_0_0_no_wan_restart
     r1_0_0_firewallzone_uplink
     r1_0_0_change_to_ffuplink
+    r1_0_0_update_preliminary_glinet_names
   fi
 
   # overwrite version with the new version

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -338,6 +338,7 @@ r1_0_0_update_preliminary_glinet_names() {
 }
 
 r1_0_0_upstream() {
+  log "applying upstream changes / sync with upstream"
   grep -q "^kernel.core_pattern=" /etc/sysctl.conf || echo >>/etc/sysctl.conf "kernel.core_pattern=/tmp/%e.%t.%p.%s.core"
   sed -i '/^net.ipv4.tcp_ecn=0/d' /etc/sysctl.conf
   grep -q "^128" /etc/iproute2/rt_tables || echo >>/etc/iproute2/rt_tables "128	prelocal"

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -281,6 +281,17 @@ r1_0_0_change_to_ffuplink() {
       return 1
     fi
   }
+  remove_routingpolicy() {
+    local config=$1
+    case "$config" in
+      olsr_*_ffvpn_ipv4*) 
+        log "  network.$config"
+        uci delete network.$config
+        ;;
+      *) ;;
+    esac
+  }
+
   log "changing interface ffvpn to ffuplink"
   log " setting wan as bridge"
   uci set network.wan.type=bridge
@@ -304,6 +315,10 @@ r1_0_0_change_to_ffuplink() {
   reset_cb
   config_load olsrd
   config_foreach change_olsrd_dygw_ping_iface LoadPlugin
+  log " removing deprecated IP-rules"
+  reset_cb
+  config_load network
+  config_foreach remove_routingpolicy rule
 }
 
 migrate () {

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -337,6 +337,15 @@ r1_0_0_update_preliminary_glinet_names() {
   esac
 }
 
+r1_0_0_upstream() {
+  grep -q "^kernel.core_pattern=" /etc/sysctl.conf || echo >>/etc/sysctl.conf "kernel.core_pattern=/tmp/%e.%t.%p.%s.core"
+  sed -i '/^net.ipv4.tcp_ecn=0/d' /etc/sysctl.conf
+  grep -q "^128" /etc/iproute2/rt_tables || echo >>/etc/iproute2/rt_tables "128	prelocal"
+  cp /rom/etc/inittab /etc/inittab
+  cp /rom/etc/profile /etc/profile
+  cp /rom/etc/hosts /etc/hosts
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -382,6 +391,7 @@ migrate () {
     r1_0_0_firewallzone_uplink
     r1_0_0_change_to_ffuplink
     r1_0_0_update_preliminary_glinet_names
+    r1_0_0_upstream
   fi
 
   # overwrite version with the new version

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -246,7 +246,6 @@ set_ipversion_olsrd6() {
 r1_0_0_vpn03_splitconfig() {
   log "changing guard-entry for VPN03 from openvpn to vpn03-openvpn (config-split for VPN03)"
   guard_rename openvpn vpn03_openvpn # to guard the current settings of package "freifunk-berlin-vpn03-files"
-  guard openvpn # to guard the current settings of package "freifunk-berlin-openvpn-files"
 }
 
 r1_0_0_no_wan_restart() {


### PR DESCRIPTION
The bbbdigger is planned as a potential replacement for the bbb-vpn using tunneldigger (l2tp).

The complete workings of the bbbdigger package is contained in the postinst script which sets all the uci options needed in tunneldigger, network, firewall, and olsrd.  After changing the settings, the script also loads the changes (reload_config) and restarts tunneldigger (/etc/init.d/tunneldigger restart).  

Afterwards there is no user interaction or reboot necessary for the mesh island to join the Berliner Backbone.
