### PR TITLE
Addon bbbdigger - an openwrt package to connect to the Berliner Backbone

### DIFF
--- a/addons/bbbdigger/Makefile
+++ b/addons/bbbdigger/Makefile
@@ -32,13 +32,6 @@ define Package/bbbdigger/description
   Freifunk Berlin configuration of tunneldigger to connect to and mesh with the Berlin Backbone
 endef
 
-define Download/ubnt_mibs
-	URL_FILE:=ubnt-mib.zip
-	URL:=https://www.ubnt.com/downloads/firmwares/airos-ubnt-mib/
-	MD5SUM:=7e7dff89b99e51336c09c4e4dad53287
-	FILE:=$(UBIQUITI_MIBS_REL)
-endef
-
 define Build/Prepare
 endef
 

--- a/addons/bbbdigger/Makefile
+++ b/addons/bbbdigger/Makefile
@@ -1,0 +1,61 @@
+#
+# Copyright (C) 2016 Freifunk Berlin
+#
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=bbbdigger
+PKG_VERSION:=0.0.1
+PKG_RELEASE:=0
+
+PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/bbbdigger/default
+  SECTION:=freifunk-berlin
+  CATEGORY:=freifunk-berlin
+  URL:=http://github.com/freifunk-berlin/packages_berlin
+  PKGARCH:=all
+endef
+
+define Package/bbbdigger
+  $(call Package/bbbdigger/default)
+  TITLE:=A Tunneldigger (l2tp) based VPN connection to mesh with the Berlin Backbone
+  DEPENDS:=+tunneldigger
+endef
+
+define Package/bbbdigger/description
+  Freifunk Berlin configuration of tunneldigger to connect to and mesh with the Berlin Backbone
+endef
+
+define Download/ubnt_mibs
+	URL_FILE:=ubnt-mib.zip
+	URL:=https://www.ubnt.com/downloads/firmwares/airos-ubnt-mib/
+	MD5SUM:=7e7dff89b99e51336c09c4e4dad53287
+	FILE:=$(UBIQUITI_MIBS_REL)
+endef
+
+define Build/Prepare
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/bbbdigger/install
+	$(INSTALL_DIR) $(1)/tmp
+	$(INSTALL_BIN) ./files/postinst.sh $(1)/tmp/bbbdigger_postinst.sh
+endef
+
+define Package/bbbdigger/postinst
+#!/bin/sh
+$${IPKG_INSTROOT}/tmp/bbbdigger_postinst.sh
+endef
+
+$(eval $(call BuildPackage,bbbdigger))

--- a/addons/bbbdigger/files/postinst.sh
+++ b/addons/bbbdigger/files/postinst.sh
@@ -1,72 +1,80 @@
 #!/bin/sh
+#
+# As part of the install, we don't want to smash an already set up config
+# but at the same time update it if necessary.  The unique attributes are:
+#
+# network.bbbdigger_dev.macaddr
+# tunneldigger.bbbdigger.uuid
+#
+# All other config sections are overwritten with current settings
 
 . /lib/functions.sh
 
-BBBDIGGER_SERV='77.87.51.51:8942'
+TUNNEL_SERV='77.87.51.51:8942'
+IFACE=bbbdigger
 
 # tunneldigger UUID (and MAC) generation, if there isn't one already
-UUID=$(uci get tunneldigger.bbbdigger.uuid)
+MAC=$(uci -q get network.${IFACE}_dev.macaddr)
 if [ $? -eq 1 ]; then
-  UUID="b6"
+  # start with b6 for Berliner 6ackbone
+  MAC="b6"
   for byte in 2 3 4 5 6; do
+    MAC=$MAC`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
+  done
+fi
+
+UUID=$(uci -q get tunneldigger.${IFACE}.uuid)
+if [ $? -eq 1 ]; then
+  UUID=$MAC
+  for byte in 7 8 9 10; do
     UUID=$UUID`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
   done
-
 fi
-echo $UUID
-
-# remove all existing bbbdigger refences from the config files
-uci delete tunneldigger.bbbdigger
-uci delete network.bbbdigger
-uci delete network.bbbdigger_dev
-uci delete network.olsr_tunnel_bbbdigger_ipv4
-uci delete network.olsr_default_bbbdigger_ipv4
-uci delete network.olsr_default_unreachable_bbbdigger_ipv4
-ZONE=$(uci show firewall.zone_freifunk.network | cut -d \' -f 2 | sed 's/ *bbbdigger *//g')
-uci set firewall.zone_freifunk.network="${ZONE}"
-uci delete $(uci show olsrd | grep bbbdigger | cut -d = -f 1)
-
-#uci changes
 
 # tunneldigger setup
-uci set tunneldigger.bbbdigger=broker
-uci add_list tunneldigger.bbbdigger.address=$BBBDIGGER_SERV
-uci set tunneldigger.bbbdigger.uuid=$UUID
-uci set tunneldigger.bbbdigger.interface=bbbvpn
-uci set tunneldigger.bbbdigger.broker_selection=usage
-uci set tunneldigger.bbbdigger.enabled=1
+uci set tunneldigger.$IFACE=broker
+uci -q delete tunneldigger.$IFACE.address
+uci add_list tunneldigger.$IFACE.address=$TUNNEL_SERV
+uci set tunneldigger.$IFACE.uuid=$UUID
+uci set tunneldigger.$IFACE.interface=$IFACE
+uci set tunneldigger.$IFACE.broker_selection=usage
+uci set tunneldigger.$IFACE.enabled=1
 
 # network setup
-uci set network.bbbdigger_dev=device
-uci set network.bbbdigger_dev.macaddr=$UUID
-uci set network.bbbdigger_dev.name=bbbdigger
-uci set network.bbbdigger=interface
-uci set network.bbbdigger.proto=dhcp
-uci set network.bbbdigger.ifname=bbbdigger
+uci set network.${IFACE}_dev=device
+uci set network.${IFACE}_dev.macaddr=$MAC
+uci set network.${IFACE}_dev.name=$IFACE
 
-uci set network.olsr_tunnel_bbbdigger_ipv4=rule
-uci set network.olsr_tunnel_bbbdigger_ipv4.lookup=olsr-tunnel
-uci set network.olsr_tunnel_bbbdigger_ipv4.priority=19999
-uci set network.olsr_tunnel_bbbdigger_ipv4.in=bbbdigger
+uci set network.$IFACE=interface
+uci set network.$IFACE.proto=dhcp
+uci set network.$IFACE.ifname=$IFACE
 
-uci set network.olsr_default_bbbdigger_ipv4=rule
-uci set network.olsr_default_bbbdigger_ipv4.lookup=olsr-default
-uci set network.olsr_default_bbbdigger_ipv4.priority=20000
-uci set network.olsr_default_bbbdigger_ipv4.in=bbbdigger
+uci set network.olsr_tunnel_$IFACE_ipv4=rule
+uci set network.olsr_tunnel_$IFACE_ipv4.lookup=olsr-tunnel
+uci set network.olsr_tunnel_$IFACE_ipv4.priority=19999
+uci set network.olsr_tunnel_$IFACE_ipv4.in=$IFACE
 
-uci set network.olsr_default_unreachable_bbbdigger_ipv4=rule
-uci set network.olsr_default_unreachable_bbbdigger_ipv4.action=unreachable
-uci set network.olsr_default_unreachable_bbbdigger_ipv4.priority=20001
-uci set network.olsr_default_unreachable_bbbdigger_ipv4.in=bbbdigger
+uci set network.olsr_default_$IFACE_ipv4=rule
+uci set network.olsr_default_$IFACE_ipv4.lookup=olsr-default
+uci set network.olsr_default_$IFACE_ipv4.priority=20000
+uci set network.olsr_default_$IFACE_ipv4.in=$IFACE
+
+uci set network.olsr_default_unreachable_$IFACE_ipv4=rule
+uci set network.olsr_default_unreachable_$IFACE_ipv4.action=unreachable
+uci set network.olsr_default_unreachable_$IFACE_ipv4.priority=20001
+uci set network.olsr_default_unreachable_$IFACE_ipv4.in=$IFACE
  
-# firewall setup
-ZONE="$ZONE bbbdigger"
+# firewall setup (first remove from the zone and add it back)
+ZONE=$(echo $(uci show firewall.zone_freifunk.network | cut -d \' -f 2 | sed "s/${IFACE}//g"))
+ZONE="$ZONE $IFACE"
 uci set firewall.zone_freifunk.network="${ZONE}"
 
-# olsr setup
+# olsr setup (first remove it and add it again)
+SECTION=$(uci show olsrd | grep ${IFACE} | cut -d . -f 1-2)
+[ ! -z $SECTION ] && uci delete $SECTION
 uci add olsrd Interface
 uci set olsrd.@Interface[-1].ignore=0
-uci set olsrd.@Interface[-1].interface=bbbdigger
+uci set olsrd.@Interface[-1].interface=$IFACE
 uci set olsrd.@Interface[-1].Mode=ether
 
 #uci changes

--- a/addons/bbbdigger/files/postinst.sh
+++ b/addons/bbbdigger/files/postinst.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+# clear out all bbbdigger settings
+
+# tunneldigger
+uci del tunneldigger.bbbdigger
+
+# network
+uci del network.interface.bbbdigger
+uci del network.device.bbbdigger
+# create bbbdigger setup
+
+# tunneldigger
+uci set tunneldigger.bbbdigger=broker
+uci set tunneldigger.bbbdigger.enabled=1
+uci add_list tunneldigger.bbbdigger.address='77.87.51.51:8942'
+uci set tunneldigger.bbbdigger.uuid=$UUID
+uci set tunneldigger.bbbdigger.interface=bbbvpn
+uci set tunneldigger.bbbdigger.broker_selection=usage
+

--- a/addons/bbbdigger/files/postinst.sh
+++ b/addons/bbbdigger/files/postinst.sh
@@ -80,3 +80,5 @@ uci set olsrd.@Interface[-1].Mode=ether
 #uci changes
 
 uci commit
+reload_config
+/etc/init.d/tunneldigger restart

--- a/addons/bbbdigger/files/postinst.sh
+++ b/addons/bbbdigger/files/postinst.sh
@@ -2,21 +2,73 @@
 
 . /lib/functions.sh
 
-# clear out all bbbdigger settings
+BBBDIGGER_SERV='77.87.51.51:8942'
 
-# tunneldigger
-uci del tunneldigger.bbbdigger
+# tunneldigger UUID (and MAC) generation, if there isn't one already
+UUID=$(uci get tunneldigger.bbbdigger.uuid)
+if [ $? -eq 1 ]; then
+  UUID="b6"
+  for byte in 2 3 4 5 6; do
+    UUID=$UUID`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
+  done
 
-# network
-uci del network.interface.bbbdigger
-uci del network.device.bbbdigger
-# create bbbdigger setup
+fi
+echo $UUID
 
-# tunneldigger
+# remove all existing bbbdigger refences from the config files
+uci delete tunneldigger.bbbdigger
+uci delete network.bbbdigger
+uci delete network.bbbdigger_dev
+uci delete network.olsr_tunnel_bbbdigger_ipv4
+uci delete network.olsr_default_bbbdigger_ipv4
+uci delete network.olsr_default_unreachable_bbbdigger_ipv4
+ZONE=$(uci show firewall.zone_freifunk.network | cut -d \' -f 2 | sed 's/ *bbbdigger *//g')
+uci set firewall.zone_freifunk.network="${ZONE}"
+uci delete $(uci show olsrd | grep bbbdigger | cut -d = -f 1)
+
+#uci changes
+
+# tunneldigger setup
 uci set tunneldigger.bbbdigger=broker
-uci set tunneldigger.bbbdigger.enabled=1
-uci add_list tunneldigger.bbbdigger.address='77.87.51.51:8942'
+uci add_list tunneldigger.bbbdigger.address=$BBBDIGGER_SERV
 uci set tunneldigger.bbbdigger.uuid=$UUID
 uci set tunneldigger.bbbdigger.interface=bbbvpn
 uci set tunneldigger.bbbdigger.broker_selection=usage
+uci set tunneldigger.bbbdigger.enabled=1
 
+# network setup
+uci set network.bbbdigger_dev=device
+uci set network.bbbdigger_dev.macaddr=$UUID
+uci set network.bbbdigger_dev.name=bbbdigger
+uci set network.bbbdigger=interface
+uci set network.bbbdigger.proto=dhcp
+uci set network.bbbdigger.ifname=bbbdigger
+
+uci set network.olsr_tunnel_bbbdigger_ipv4=rule
+uci set network.olsr_tunnel_bbbdigger_ipv4.lookup=olsr-tunnel
+uci set network.olsr_tunnel_bbbdigger_ipv4.priority=19999
+uci set network.olsr_tunnel_bbbdigger_ipv4.in=bbbdigger
+
+uci set network.olsr_default_bbbdigger_ipv4=rule
+uci set network.olsr_default_bbbdigger_ipv4.lookup=olsr-default
+uci set network.olsr_default_bbbdigger_ipv4.priority=20000
+uci set network.olsr_default_bbbdigger_ipv4.in=bbbdigger
+
+uci set network.olsr_default_unreachable_bbbdigger_ipv4=rule
+uci set network.olsr_default_unreachable_bbbdigger_ipv4.action=unreachable
+uci set network.olsr_default_unreachable_bbbdigger_ipv4.priority=20001
+uci set network.olsr_default_unreachable_bbbdigger_ipv4.in=bbbdigger
+ 
+# firewall setup
+ZONE="$ZONE bbbdigger"
+uci set firewall.zone_freifunk.network="${ZONE}"
+
+# olsr setup
+uci add olsrd Interface
+uci set olsrd.@Interface[-1].ignore=0
+uci set olsrd.@Interface[-1].interface=bbbdigger
+uci set olsrd.@Interface[-1].Mode=ether
+
+#uci changes
+
+uci commit

--- a/defaults/freifunk-berlin-openvpn-files/Makefile
+++ b/defaults/freifunk-berlin-openvpn-files/Makefile
@@ -3,8 +3,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-openvpn-files
-PKG_VERSION:=0.0.7
-PKG_RELEASE:=2
+PKG_VERSION:=0.0.8
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -40,8 +40,6 @@ define Package/freifunk-berlin-openvpn-files/install
 	$(CP) ./openvpn/ffvpn-up.sh $(1)/lib/freifunk
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
 	$(CP) ./openvpn/60-ffopenvpn $(1)/etc/hotplug.d/iface
-	$(INSTALL_DIR) $(1)/etc/config
-	$(CP) ./files/ffberlin-uplink $(1)/etc/config
 endef
 
 $(eval $(call BuildPackage,freifunk-berlin-openvpn-files))

--- a/defaults/freifunk-berlin-openvpn-files/files/ffberlin-uplink
+++ b/defaults/freifunk-berlin-openvpn-files/files/ffberlin-uplink
@@ -1,4 +1,0 @@
-
-config settings uplink
-        option auth 'x509'
-

--- a/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
+++ b/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-openvpn
@@ -1,5 +1,11 @@
 #!/bin/sh
 
+# set set auth-type required for this uplink-type, e.g. for freifunk-wizard
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
+uci set ffberlin-uplink.uplink=settings
+uci set ffberlin-uplink.uplink.auth=x509
+uci commit ffberlin-uplink.uplink
+
 uci -q delete openvpn.custom_config
 uci -q delete openvpn.sample_server
 uci -q delete openvpn.sample_client

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-notunnel-files
-PKG_VERSION:=0.0.5
+PKG_VERSION:=0.0.6
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
@@ -40,8 +40,6 @@ define Package/$(PKG_NAME)/install
 	$(CP) ./uci-defaults/* $(1)/etc/uci-defaults
 	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
 	$(CP) ./files/60-ffuplink $(1)/etc/hotplug.d/iface
-	$(INSTALL_DIR) $(1)/etc/config
-	$(CP) ./files/ffberlin-uplink $(1)/etc/config
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/files/ffberlin-uplink
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/files/ffberlin-uplink
@@ -1,4 +1,0 @@
-
-config settings uplink
-        option auth 'none'
-

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -4,6 +4,23 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
+# create ffberlin-uplink file an fill with basic settings
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
+uci >/dev/null -q get ffberlin-uplink.preset || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci set ffberlin-uplink.preset.current="no-tunnel"
+if [[ $(uci get ffberlin-uplink.preset.current) != "no-tunnel" ]]; then
+  uci rename ffberlin-uplink.preset.current=previous
+  uci set ffberlin-uplink.preset.current="no-tunnel"
+fi
+# set set auth-type required for this uplink-type, e.g. for freifunk-wizard
+uci set ffberlin-uplink.uplink=settings
+uci set ffberlin-uplink.uplink.auth=none
+
+uci commit ffberlin-uplink
+
+. /lib/functions/guard.sh
+guard "notunnel"
+
 uci delete network.ffuplink_dev
 uci set network.ffuplink_dev=device
 uci set network.ffuplink_dev.type=veth
@@ -11,10 +28,7 @@ uci set network.ffuplink_dev.name=ffuplink
 uci set network.ffuplink_dev.peer_name=ffuplink_wan
 # add ffuplink_dev to br-wan
 uci set network.wan.ifname="$(uci get network.wan.ifname) ffuplink_wan"
-uci commit network
-
-. /lib/functions/guard.sh
-guard "notunnel"
+uci commit network.ffuplink_dev
 
 uci delete network.ffuplink
 uci set network.ffuplink=interface

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/Makefile
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-tunnelberlin-files
-PKG_VERSION:=0.0.2
+PKG_VERSION:=0.0.3
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-tunnelberlin-openvpn
@@ -4,6 +4,15 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
+uci >/dev/null -q get ffberlin-uplink.preset || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
+if [[ $(uci get ffberlin-uplink.preset.current) != '"tunnelberlin_openvpn"' ]]; then
+  uci rename ffberlin-uplink.preset.current=previous
+  uci set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
+fi
+uci commit ffberlin-uplink
+
 . /lib/functions/guard.sh
 guard "tunnelberlin_openvpn"
 

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/Makefile
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-vpn03-files
-PKG_VERSION:=0.0.4
+PKG_VERSION:=0.0.5
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-vpn03
@@ -4,6 +4,15 @@
 uci set firewall.zone_ffuplink.masq=0
 uci commit firewall
 
+uci -q get ffberlin-uplink || echo "" | uci import ffberlin-uplink
+uci >/dev/null -q get ffberlin-uplink.preset || uci set ffberlin-uplink.preset=settings
+uci >/dev/null -q get ffberlin-uplink.preset.current || uci set ffberlin-uplink.preset.current="vpn03_openvpn"
+if [[ $(uci get ffberlin-uplink.preset.current) != 'vpn03_openvpn' ]]; then
+  uci rename ffberlin-uplink.preset.current=previous
+  uci set ffberlin-uplink.preset.current="vpn03_openvpn"
+fi
+uci commit ffberlin-uplink
+
 . /lib/functions/guard.sh
 guard "vpn03_openvpn"
 

--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
-PKG_VERSION:=0.4.5
+PKG_VERSION:=0.4.7
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -246,7 +246,6 @@ set_ipversion_olsrd6() {
 r1_0_0_vpn03_splitconfig() {
   log "changing guard-entry for VPN03 from openvpn to vpn03-openvpn (config-split for VPN03)"
   guard_rename openvpn vpn03_openvpn # to guard the current settings of package "freifunk-berlin-vpn03-files"
-  guard openvpn # to guard the current settings of package "freifunk-berlin-openvpn-files"
 }
 
 r1_0_0_no_wan_restart() {
@@ -281,6 +280,17 @@ r1_0_0_change_to_ffuplink() {
       return 1
     fi
   }
+  remove_routingpolicy() {
+    local config=$1
+    case "$config" in
+      olsr_*_ffvpn_ipv4*) 
+        log "  network.$config"
+        uci delete network.$config
+        ;;
+      *) ;;
+    esac
+  }
+
   log "changing interface ffvpn to ffuplink"
   log " setting wan as bridge"
   uci set network.wan.type=bridge
@@ -304,7 +314,71 @@ r1_0_0_change_to_ffuplink() {
   reset_cb
   config_load olsrd
   config_foreach change_olsrd_dygw_ping_iface LoadPlugin
+  log " removing deprecated IP-rules"
+  reset_cb
+  config_load network
+  config_foreach remove_routingpolicy rule
 }
+
+r1_0_0_update_preliminary_glinet_names() {
+  case `uci get system.led_wlan.sysfs` in
+    "gl_ar150:wlan")
+      log "correcting system.led_wlan.sysfs for GLinet AR150"
+      uci set system.led_wlan.sysfs="gl-ar150:wlan"
+      ;;
+    "gl_ar300:wlan")
+      log "correcting system.led_wlan.sysfs for GLinet AR300"
+      uci set system.led_wlan.sysfs="gl-ar300:wlan"
+      ;;
+    "domino:blue:wlan")
+      log "correcting system.led_wlan.sysfs for GLinet Domino"
+      uci set system.led_wlan.sysfs="gl-domino:blue:wlan"
+      ;;
+  esac
+}
+
+r1_0_0_upstream() {
+  log "applying upstream changes / sync with upstream"
+  grep -q "^kernel.core_pattern=" /etc/sysctl.conf || echo >>/etc/sysctl.conf "kernel.core_pattern=/tmp/%e.%t.%p.%s.core"
+  sed -i '/^net.ipv4.tcp_ecn=0/d' /etc/sysctl.conf
+  grep -q "^128" /etc/iproute2/rt_tables || echo >>/etc/iproute2/rt_tables "128	prelocal"
+  cp /rom/etc/inittab /etc/inittab
+  cp /rom/etc/profile /etc/profile
+  cp /rom/etc/hosts /etc/hosts
+  log " checking for user dnsmasq"
+  group_exists "dnsmasq" || group_add "dnsmasq" "453"
+  user_exists "dnsmasq" || user_add "dnsmasq" "453" "453"
+}
+
+r1_0_0_set_uplinktype() {
+  log "storing used uplink-type"
+  log " migrating from Kathleen-release, assuming VPN03 as uplink-preset"
+  echo "" | uci import ffberlin-uplink
+  uci set ffberlin-uplink.preset=settings
+  uci set ffberlin-uplink.preset.current="vpn03_openvpn"
+}
+
+r1_0_1_set_uplinktype() {
+  uci >/dev/null -q get ffberlin-uplink.preset && return 0
+
+  log "storing used uplink-type for Hedy"
+  uci set ffberlin-uplink.preset=settings
+  uci set ffberlin-uplink.preset.current="unknown"
+  if [ "$(uci -q get network.ffuplink_dev.type)" = "veth" ]; then
+    uci set ffberlin-uplink.preset.current="no-tunnel"
+  else
+    case "$(uci -q get openvpn.ffuplink.remote)" in
+      \'vpn03.berlin.freifunk.net*)
+        uci set ffberlin-uplink.preset.current="vpn03_openvpn"
+        ;;
+      \'tunnel-gw.berlin.freifunk.net*)
+        uci set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
+        ;;
+    esac
+    fi
+  log " type set to $(uci get ffberlin-uplink.preset.current)"
+}
+
 
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
@@ -350,6 +424,13 @@ migrate () {
     r1_0_0_no_wan_restart
     r1_0_0_firewallzone_uplink
     r1_0_0_change_to_ffuplink
+    r1_0_0_update_preliminary_glinet_names
+    r1_0_0_upstream
+    r1_0_0_set_uplinktype
+  fi
+
+  if semverLT ${OLD_VERSION} "1.0.1"; then
+    r1_0_1_set_uplinktype
   fi
 
   # overwrite version with the new version


### PR DESCRIPTION
The old bbbvpn has not been maintained in a long time.  Along with this, there is a compatibility problem with the tunnel-berlin version of the firmware and the certificates for the old bbbvpn.

The bbbdigger package is a wrapper for tunneldigger with all the needed configuration done automatically.  In order to have a mesh-island connect with the rest of the Berliner Backbone, one needs only to ```opkg install bbbdigger```. 

Some feedback on the postinit script is definitely welcome.  A possible TODO is to change the postinit script from a static IP address to a hostname.