### PR TITLE
dhcp-defaults: always announce a IPv6 default-route via us

### DIFF
--- a/defaults/freifunk-berlin-dhcp-defaults/uci-defaults/freifunk-berlin-dhcp-defaults
+++ b/defaults/freifunk-berlin-dhcp-defaults/uci-defaults/freifunk-berlin-dhcp-defaults
@@ -6,6 +6,10 @@ guard "dhcp"
 # quieten down dnsmasq a bit (do not log lease-mgmt)
 uci set dhcp.@dnsmasq[0].quietdhcp=1
 
+# on IPv6-islands we also should give a default-route to the clients,
+# so they can also reach IPv6-neighbours. 
+uci set dhcp.dhcp.ra_default=1
+
 # add dns entry frei.funk
 uci set dhcp.frei_funk=domain
 uci set dhcp.frei_funk.name=frei.funk


### PR DESCRIPTION
On Ipv6-islands, we do not have a public prefix and dnsmasq will not announce a default-route via us. This gives clients only v6-connectivity to the hosts in the local LAN-segment. 
With this option the client can also reach other hosts on the olsr-net.