### PR TITLE
uplink-notunnel: simplify creation of static macaddress

### DIFF
--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+. /lib/functions/system.sh
+
 # always set correct masquerading, regardless of guard
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
@@ -26,12 +28,9 @@ uci set network.ffuplink_dev=device
 uci set network.ffuplink_dev.type=veth
 uci set network.ffuplink_dev.name=ffuplink
 uci set network.ffuplink_dev.peer_name=ffuplink_wan
-# Create a static macaddr starting with "fe" for ffuplink devices
-macaddr="fe"
-for byte in 2 3 4 5 6; do
-  macaddr=$macaddr`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
-done
-uci set network.ffuplink_dev.macaddr=$macaddr
+# Create a static random macaddr for ffuplink device
+macaddr=$(macaddr_canonicalize `dd 2>/dev/null bs=1 count=6 </dev/urandom | hexdump -e '1/1 "%02x"'`)
+uci set network.ffuplink_dev.macaddr=$(macaddr_setbit_la $macaddr)
 
 # add ffuplink_dev to br-wan
 uci set network.wan.ifname="$(uci get network.wan.ifname) ffuplink_wan"

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -4,6 +4,7 @@ source /lib/functions.sh
 source /lib/functions/semver.sh
 source /etc/openwrt_release
 source /lib/functions/guard.sh
+source /lib/functions/system.sh
 
 # possible cases: 
 # 1) firstboot with kathleen --> uci system.version not defined
@@ -404,11 +405,8 @@ r1_1_0_notunnel_ffuplink() {
     log "update the ffuplink_dev to have a static macaddr if not already set"
     local macaddr=$(uci -q get network.ffuplink_dev.macaddr)
     if [ $? -eq 1 ]; then
-      # start with fe for ffuplink devices
-      macaddr="fe"
-      for byte in 2 3 4 5 6; do
-        macaddr=$macaddr`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
-      done
+      # Create a static random macaddr for ffuplink device
+      macaddr=$(macaddr_canonicalize `dd 2>/dev/null bs=1 count=6 </dev/random | hexdump -e '1/1 "%02x"'`)
     fi
     uci set network.ffuplink_dev.macaddr=$macaddr
   fi

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -406,9 +406,9 @@ r1_1_0_notunnel_ffuplink() {
     local macaddr=$(uci -q get network.ffuplink_dev.macaddr)
     if [ $? -eq 1 ]; then
       # Create a static random macaddr for ffuplink device
-      macaddr=$(macaddr_canonicalize `dd 2>/dev/null bs=1 count=6 </dev/random | hexdump -e '1/1 "%02x"'`)
+      macaddr=$(macaddr_canonicalize `dd 2>/dev/null bs=1 count=6 </dev/urandom | hexdump -e '1/1 "%02x"'`)
+      uci set network.ffuplink_dev.macaddr=$(macaddr_setbit_la $macaddr)
     fi
-    uci set network.ffuplink_dev.macaddr=$macaddr
   fi
 }
 


### PR DESCRIPTION
use the functions provided by OpenWrt to format the address and set to "LAA"-bit.

* was tested in an separate script 
* looks more elegant than the loop before