### PR TITLE
hotplug 60-ffopenvpn: remove local declaration of variables

### DIFF
--- a/defaults/freifunk-berlin-openvpn-files/openvpn/60-ffopenvpn
+++ b/defaults/freifunk-berlin-openvpn-files/openvpn/60-ffopenvpn
@@ -4,7 +4,6 @@
 . /lib/functions/network.sh
 
 config_load ffwizard
-local sharenet
 config_get sharenet settings sharenet
 
 [ "$sharenet" = 1 ] || exit
@@ -15,7 +14,6 @@ config_get sharenet settings sharenet
 [ "$INTERFACE" = wan ] || exit
 
 config_load openvpn
-local uci_vpn_enabled
 config_get uci_vpn_enabled ffuplink enabled
 
 if [ "$ACTION" = ifup ]; then
@@ -23,7 +21,6 @@ if [ "$ACTION" = ifup ]; then
   if [ "$uci_vpn_enabled" = 1 ]; then
     logger -t ff-vpn-hotplug "Starting OpenVPN on WAN interface"
     # Make sure OpenVPN connects only through WAN: set "local" option with WAN IP
-    local wanip
     network_get_ipaddr wanip "wan"
     uci set openvpn.ffuplink.local=$wanip
     uci commit openvpn


### PR DESCRIPTION
Declarations of variables outside of a function result in the script silently failing.  All such variable declarations have been removed.