### PR TITLE
luci-app-owm: replace sys.net.arptable with luci.ip.neighbors in owm.lua

### DIFF
--- a/utils/luci-app-owm/luasrc/owm.lua
+++ b/utils/luci-app-owm/luasrc/owm.lua
@@ -444,7 +444,7 @@ function get()
 	end)
 
 	local neighbors = fetch_olsrd_neighbors(root.interfaces)
-	local arptable = sys.net.arptable() or {}
+	local arptable = luci.ip.neighbors() or {}
 	if #root.interfaces ~= 0 then
 		for idx,iface in ipairs(root.interfaces) do
 			local neigh_mac = {}


### PR DESCRIPTION
With a commit in the luci code base the function luci.sys.net.arptable
was replaced by luci.ip.neighbors:

https://github.com/openwrt/luci/commit/366707a681459a4d520dc97024ea0a4b3c24a326

The missing function definition caused the owm.lua program to fail.

Fixes https://github.com/freifunk-berlin/firmware/issues/507

Untested. Please test before merge.