### PR TITLE
luci-app-owm: change field names for arptable in owm.lua

### DIFF
--- a/utils/luci-app-owm/luasrc/owm.lua
+++ b/utils/luci-app-owm/luasrc/owm.lua
@@ -26,7 +26,7 @@ local table = require "table"
 local nixio = require "nixio"
 local ip = require "luci.ip"
 
-local ipairs, pairs, tonumber = ipairs, pairs, tonumber
+local ipairs, pairs, tonumber, tostring = ipairs, pairs, tonumber, tostring
 local dofile, _G = dofile, _G
 
 --- LuCI OWM-Library
@@ -449,9 +449,9 @@ function get()
 		for idx,iface in ipairs(root.interfaces) do
 			local neigh_mac = {}
 			for _, arpt in ipairs(arptable) do
-				local mac = showmac(arpt['HW address']:lower())
-				local ip_addr = arpt['IP address']
-				if iface['ifname'] == arpt['Device'] then
+				local mac = showmac(tostring(arpt['mac']):lower())
+				local ip_addr = tostring(arpt['dest'])
+				if iface['ifname'] == tostring(arpt['dev']) then
 					if not neigh_mac[mac] then
 						neigh_mac[mac] = {}
 						neigh_mac[mac]['ip4'] = {}


### PR DESCRIPTION
With a commit in the luci code base the function luci.sys.net.arptable
was replaced by luci.ip.neighbors:

https://github.com/openwrt/luci/commit/366707a681459a4d520dc97024ea0a4b3c24a326

The field names of the returned table are different to the old field
names. Therefore we have to change the field names. The values of the
table are of type userdata and we have to convert to string with the
tostring method.