### PR TITLE
bbbdigger: change server IP address to FQDN

### DIFF
--- a/addons/freifunk-berlin-bbbdigger/Makefile
+++ b/addons/freifunk-berlin-bbbdigger/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-bbbdigger
-PKG_VERSION:=0.0.1
+PKG_VERSION:=0.0.2
 PKG_RELEASE:=0
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/addons/freifunk-berlin-bbbdigger/files/postinst.sh
+++ b/addons/freifunk-berlin-bbbdigger/files/postinst.sh
@@ -10,7 +10,7 @@
 
 . /lib/functions.sh
 
-TUNNEL_SERV='77.87.51.51:8942'
+TUNNEL_SERV='a.bbb-vpn.berlin.freifunk.net:8942 b.bbb-vpn.berlin.freifunk.net:8942'
 IFACE=bbbdigger
 
 # tunneldigger UUID (and MAC) generation, if there isn't one already
@@ -34,7 +34,9 @@ fi
 # tunneldigger setup
 uci set tunneldigger.$IFACE=broker
 uci -q delete tunneldigger.$IFACE.address
-uci add_list tunneldigger.$IFACE.address=$TUNNEL_SERV
+for srv in $TUNNEL_SERV; do
+  uci add_list tunneldigger.$IFACE.address=$srv
+done
 uci set tunneldigger.$IFACE.uuid=$UUID
 uci set tunneldigger.$IFACE.interface=$IFACE
 uci set tunneldigger.$IFACE.broker_selection=usage


### PR DESCRIPTION
The server has been changed from an IP address to a fully qualified domain name (a.bbb-vpn.berlin.freifunk.net).  Additionally a second FQDN has been added which currently does not resolve (b.bbb-vpn.berlin.freifunk.net).  The unresolvable domain name does not cause any performance issues but does result in a few warnings in the log.  