### PR TITLE
update the nameservers used in the firmware

### DIFF
--- a/defaults/freifunk-berlin-olsrd-defaults/Makefile
+++ b/defaults/freifunk-berlin-olsrd-defaults/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-olsrd-defaults
-PKG_VERSION:=0.0.5
+PKG_VERSION:=0.0.6
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/defaults/freifunk-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
+++ b/defaults/freifunk-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
@@ -41,7 +41,7 @@ uci set olsrd.$PLUGIN.interval=30
 PLUGIN="$(uci add olsrd LoadPlugin)"
 uci set olsrd.$PLUGIN.library=olsrd_dyn_gw
 uci add_list olsrd.$PLUGIN.Ping=85.214.20.141     # dns.digitalcourage.de
-uci add_list olsrd.$PLUGIN.Ping=213.73.91.35      # dnscache.ccc.berlin.de
+uci add_list olsrd.$PLUGIN.Ping=80.67.169.40      # www.fdn.fr/actions/dns
 uci add_list olsrd.$PLUGIN.Ping=194.150.168.168   # dns.as250.net
 uci set olsrd.$PLUGIN.ignore=0
 

--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
-PKG_VERSION:=0.5.1
+PKG_VERSION:=0.5.2
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -493,6 +493,7 @@ migrate () {
     r1_1_0_change_olsrd_lib_num
     r1_1_0_notunnel_ffuplink
     r1_1_0_notunnel_ffuplink_ipXtable
+    r1_1_0_olsrd_dygw_ping
   fi
 
   # overwrite version with the new version

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -420,6 +420,22 @@ r1_1_0_notunnel_ffuplink_ipXtable() {
   fi
 }
 
+r1_1_0_olsrd_dygw_ping() {
+  olsrd_dygw_ping() {
+    local config=$1
+    local lib=''
+    config_get lib $config library
+    if[ -z "${lib##olsrd_dyn_gw.so*}" ]; then
+      uci del_list olsrd.$config.Ping=213.73.91.35   # dnscache.ccc.berlin.de
+      uci add_list olsrd.$config.Ping=80.67.169.40   # www.fdn.fr/actions/dns
+      return 1
+    fi
+  }
+  reset_cb
+  config_load olsrd
+  config_foreach olsrd_dygw_ping LoadPlugin
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 

--- a/utils/freifunk-berlin-wizard-backend/Makefile
+++ b/utils/freifunk-berlin-wizard-backend/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-wizard-backend
-PKG_VERSION:=1.0.0~beta.3
+PKG_VERSION:=1.0.0~beta.4
 PKG_RELEASE:=1
 PKG_MAINTAINER:=André Gaul <andre@gaul.io>
 

--- a/utils/freifunk-berlin-wizard-backend/files/usr/lib/ffwizard.d/20-network.sh
+++ b/utils/freifunk-berlin-wizard-backend/files/usr/lib/ffwizard.d/20-network.sh
@@ -130,7 +130,7 @@ setup_network() {
   fi
 
   # dns
-  uci set network.loopback.dns="85.214.20.141 213.73.91.35 194.150.168.168 2001:4ce8::53 2001:910:800::12"
+  uci set network.loopback.dns="85.214.20.141 80.67.169.40 194.150.168.168 2001:4ce8::53 2001:910:800::12"
 
   # set table for wan
   # TODO: re-enable when olsr is fixed for non-default routing tables

--- a/utils/freifunk-berlin-wizard-backend/files/usr/lib/ffwizard.d/30-olsrd.sh
+++ b/utils/freifunk-berlin-wizard-backend/files/usr/lib/ffwizard.d/30-olsrd.sh
@@ -95,7 +95,7 @@ EOF
     uci set olsrd.$PLUGIN.PingCmd="ping -c 1 -q -I $uplinkDev %s"
     uci set olsrd.$PLUGIN.PingInterval=30
     uci add_list olsrd.$PLUGIN.Ping=85.214.20.141     # dns.digitalcourage.de
-    uci add_list olsrd.$PLUGIN.Ping=213.73.91.35      # dnscache.ccc.berlin.de
+    uci add_list olsrd.$PLUGIN.Ping=80.67.169.40      # www.fdn.fr/actions/dns
     uci add_list olsrd.$PLUGIN.Ping=194.150.168.168   # dns.as250.net
     uci set olsrd.$PLUGIN.ignore=0
   fi


### PR DESCRIPTION
This PR is in conjunction with PR https://github.com/openwrt/luci/pull/2200.

Nameserver 80.67.169.40 is provided by the French Data Network (www.fdn.fr/actions/dns)

The relevant Freifunk Issues are https://github.com/freifunk-berlin/firmware/issues/551 and https://github.com/freifunk-berlin/firmware/issues/552