### PR TITLE
Revert "uplink-notunnel: simplify creation of static macaddress"

### DIFF
--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-notunnel
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-. /lib/functions/system.sh
-
 # always set correct masquerading, regardless of guard
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
@@ -28,9 +26,12 @@ uci set network.ffuplink_dev=device
 uci set network.ffuplink_dev.type=veth
 uci set network.ffuplink_dev.name=ffuplink
 uci set network.ffuplink_dev.peer_name=ffuplink_wan
-# Create a static random macaddr for ffuplink device
-macaddr=$(macaddr_canonicalize `dd 2>/dev/null bs=1 count=6 </dev/urandom | hexdump -e '1/1 "%02x"'`)
-uci set network.ffuplink_dev.macaddr=$(macaddr_setbit_la $macaddr)
+# Create a static macaddr starting with "fe" for ffuplink devices
+macaddr="fe"
+for byte in 2 3 4 5 6; do
+  macaddr=$macaddr`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
+done
+uci set network.ffuplink_dev.macaddr=$macaddr
 
 # add ffuplink_dev to br-wan
 uci set network.wan.ifname="$(uci get network.wan.ifname) ffuplink_wan"

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -4,7 +4,6 @@ source /lib/functions.sh
 source /lib/functions/semver.sh
 source /etc/openwrt_release
 source /lib/functions/guard.sh
-source /lib/functions/system.sh
 
 # possible cases: 
 # 1) firstboot with kathleen --> uci system.version not defined
@@ -406,8 +405,11 @@ r1_1_0_notunnel_ffuplink() {
     local macaddr=$(uci -q get network.ffuplink_dev.macaddr)
     if [ $? -eq 1 ]; then
       # Create a static random macaddr for ffuplink device
-      macaddr=$(macaddr_canonicalize `dd 2>/dev/null bs=1 count=6 </dev/urandom | hexdump -e '1/1 "%02x"'`)
-      uci set network.ffuplink_dev.macaddr=$(macaddr_setbit_la $macaddr)
+      # start with fe for ffuplink devices
+      macaddr="fe"
+      for byte in 2 3 4 5 6; do
+        macaddr=$macaddr`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
+      done
     fi
   fi
 }


### PR DESCRIPTION
This reverts commit 4b379d3ea8af4fd70e62ede301ded69c92f95c4a.

The macaddress generation part of the scripts correctly flips
the U/L bit to 1, which is what we need. Unfortunately the script
does not set the LSB bit to 0.

The result is that an invalid mac address may be created, which
prevents the ffuplink and ffuplink_wan interfaces from going up.

See issue #604