### PR TITLE
Force tunneldigger connections to bind to the wan interface

### DIFF
--- a/addons/freifunk-berlin-bbbdigger/Makefile
+++ b/addons/freifunk-berlin-bbbdigger/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-bbbdigger
-PKG_VERSION:=0.0.2
+PKG_VERSION:=0.0.3
 PKG_RELEASE:=0
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/addons/freifunk-berlin-bbbdigger/files/postinst.sh
+++ b/addons/freifunk-berlin-bbbdigger/files/postinst.sh
@@ -12,6 +12,7 @@
 
 TUNNEL_SERV='a.bbb-vpn.berlin.freifunk.net:8942 b.bbb-vpn.berlin.freifunk.net:8942'
 IFACE=bbbdigger
+BIND=wan
 
 # tunneldigger UUID (and MAC) generation, if there isn't one already
 # See the website https://www.itwissen.info/MAC-Adresse-MAC-address.html
@@ -41,6 +42,7 @@ done
 uci set tunneldigger.$IFACE.uuid=$UUID
 uci set tunneldigger.$IFACE.interface=$IFACE
 uci set tunneldigger.$IFACE.broker_selection=usage
+uci set tunneldigger.$IFACE.bind_interface=$BIND
 uci set tunneldigger.$IFACE.enabled=1
 
 # network setup

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/Makefile
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-tunnelberlin-tunneldigger-files
-PKG_VERSION:=0.0.3
+PKG_VERSION:=0.0.4
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/uci-defaults/freifunk-berlin-tunnelberlin-tunneldigger
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/uci-defaults/freifunk-berlin-tunnelberlin-tunneldigger
@@ -54,6 +54,7 @@ done
 uci set tunneldigger.ffuplink.uuid=$UUID
 uci set tunneldigger.ffuplink.interface=ffuplink
 uci set tunneldigger.ffuplink.broker_selection=usage
+uci set tunneldigger.ffuplink.bind_interface=wan
 uci set tunneldigger.ffuplink.enabled=1
 uci commit tunneldigger
 


### PR DESCRIPTION
If the node is not connect to wan, but meshes, tunneldigger will attept to
build the tunnel though the smart gw. This creates an undesired loopback.
The solition is to add option bind_interface 'wan'

This issue is described in https://github.com/freifunk-berlin/firmware/issues/606