### PR TITLE
update files which reference OLSR library plugins by version number

### DIFF
--- a/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/olsr.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/olsr.lua
@@ -61,9 +61,9 @@ end
 
 function configureOLSRPlugins()
 	local suffix = uci:get_first(community, "community", "suffix") or "olsr"
-	updatePlugin("olsrd_nameservice.so.0.3", "suffix", "."..suffix)
-	updatePluginInConfig("olsrd", "olsrd_dyn_gw.so.0.5", "PingCmd", "ping -c 1 -q -I ffuplink %s")
-	updatePluginInConfig("olsrd", "olsrd_dyn_gw.so.0.5", "PingInterval", "30")
+	updatePlugin("olsrd_nameservice", "suffix", "."..suffix)
+	updatePluginInConfig("olsrd", "olsrd_dyn_gw", "PingCmd", "ping -c 1 -q -I ffuplink %s")
+	updatePluginInConfig("olsrd", "olsrd_dyn_gw", "PingInterval", "30")
 	uci:save("olsrd")
 	uci:save("olsrd6")
 end

--- a/utils/luci-mod-freifunk-ui/luasrc/view/freifunk-map/frame.htm
+++ b/utils/luci-mod-freifunk-ui/luasrc/view/freifunk-map/frame.htm
@@ -4,7 +4,7 @@
 	local has_latlon = false
 	local uci = require "luci.model.uci".cursor()
 	uci:foreach("olsrd", "LoadPlugin", function(s)
-		if s.library == "olsrd_nameservice.so.0.3" and s.latlon_file then
+		if s.library == "olsrd_nameservice" and s.latlon_file then
 			has_latlon = true
 		end
 	end)

--- a/utils/luci-mod-freifunk-ui/luasrc/view/freifunk-map/map.htm
+++ b/utils/luci-mod-freifunk-ui/luasrc/view/freifunk-map/map.htm
@@ -85,7 +85,7 @@
 					local uci = require "luci.model.uci".cursor()
 
 					uci:foreach("olsrd", "LoadPlugin", function(s)
-						if s.library == "olsrd_nameservice.so.0.3" and s.latlon_file then
+						if s.library == "olsrd_nameservice" and s.latlon_file then
 							fd = io.open(s.latlon_file)
 						end
 					end)


### PR DESCRIPTION
The version number for OLSR library plugins is not longer needed and
in many cases out of date.  This commit completes changes in
ba58e285d56f975ab6f0fad4a01a434408cacfef
5364b36f5f11cc1253258cb162767d0c52124e3c

The upstream commit which caused these changes is
https://github.com/openwrt-routing/packages/commit/f4bc87dc65729ef663f6dc9b7e157a909c5eb92b

I have compiled with these changes but I don't know what to test for.  There is another PR for luci by @booo. 

This fixes the issue in https://github.com/freifunk-berlin/firmware/issues/605
This PR is also related to  https://github.com/freifunk-berlin/firmware/issues/594