### PR TITLE
migration: fix setting a static MAC-address

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -411,6 +411,7 @@ r1_1_0_notunnel_ffuplink() {
       for byte in 2 3 4 5 6; do
         macaddr=$macaddr`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
       done
+      uci set network.ffuplink_dev.macaddr=$macaddr
     fi
   fi
 }


### PR DESCRIPTION
the generated MAC-address must be stored by uci

Or is it done in some other place?