### PR TITLE
luci-app-ffwizard-berlin: set dns entry on loopback interface

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -440,6 +440,17 @@ r1_1_0_olsrd_dygw_ping() {
   config_foreach olsrd_dygw_ping LoadPlugin
 }
 
+r1_1_0_update_dns_entry() {
+  network_interface_delete_dns() {
+    local config=${1}
+    uci -q del network.${config}.dns
+  }
+  reset_cb
+  config_load network
+  config_foreach network_interface_delete_dns Interface
+  uci set network.loopback.dns="$(uci get "profile_$(uci get freifunk.community.name).interface.dns")"
+}
+
 migrate () {
   log "Migrating from ${OLD_VERSION} to ${VERSION}."
 
@@ -498,6 +509,7 @@ migrate () {
     r1_1_0_notunnel_ffuplink
     r1_1_0_notunnel_ffuplink_ipXtable
     r1_1_0_olsrd_dygw_ping
+    r1_1_0_update_dns_entry
   fi
 
   # overwrite version with the new version

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -154,6 +154,8 @@ function main.write(self, section, value)
       ifconfig.network = calcnif(device)
       ifconfig.ifname = ifnameAdhoc
       ifconfig.mode = "adhoc"
+      -- don't set the dns entry
+      ifconfig.dns = nil
       -- uci:get needs a string as key so we convert to string with tostring()
       ifconfig.ssid = uci:get(community, "ssidscheme", tostring(devconfig.channel))
       ifconfig.bssid = uci:get(community, "bssidscheme", tostring(devconfig.channel))
@@ -200,6 +202,12 @@ function main.write(self, section, value)
 
     end)
 
+  -- Set the dns entry on the loopback interface. We set it on the loopback
+  -- interface so we only have one entry for the whole network configuration.
+  local dns = uci:get(community, "interface", "dns")
+  if (dns) then
+    uci:set("network", "loopback", "dns", dns)
+  end
 
   local dhcpmeshnet = dhcpmesh:formvalue(section)
   dhcpmeshnet = ip.IPv4(dhcpmeshnet)
@@ -208,7 +216,6 @@ function main.write(self, section, value)
   if (dhcpmeshnet:prefix() < 32) then
     --NETWORK CONFIG bridge for wifi APs
     local prenetconfig =  {}
-    prenetconfig.dns=uci:get(community, "interface", "dns")
     prenetconfig.type="bridge"
     prenetconfig.proto="static"
     prenetconfig.ipaddr=dhcpmeshnet:minhost():string()


### PR DESCRIPTION
Set the dns entry on the loopback interface. We set it on the loopback
interface so we only have one entry for the whole network configuration.