### PR TITLE
Create a tunneldigger package for freifunk-berlin

### DIFF
--- a/addons/freifunk-berlin-bbbdigger/Makefile
+++ b/addons/freifunk-berlin-bbbdigger/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-bbbdigger
-PKG_VERSION:=0.0.2
+PKG_VERSION:=0.0.3
 PKG_RELEASE:=0
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
@@ -25,7 +25,7 @@ endef
 define Package/freifunk-berlin-bbbdigger
   $(call Package/freifunk-berlin-bbbdigger/default)
   TITLE:=A Tunneldigger (l2tp) based VPN connection to mesh with the Berlin Backbone
-  DEPENDS:=+tunneldigger
+  DEPENDS:=+freifunk-berlin-tunneldigger
 endef
 
 define Package/freifunk-berlin-bbbdigger/description

--- a/addons/freifunk-berlin-bbbdigger/files/postinst.sh
+++ b/addons/freifunk-berlin-bbbdigger/files/postinst.sh
@@ -12,6 +12,7 @@
 
 TUNNEL_SERV='a.bbb-vpn.berlin.freifunk.net:8942 b.bbb-vpn.berlin.freifunk.net:8942'
 IFACE=bbbdigger
+BIND=wan
 
 # tunneldigger UUID (and MAC) generation, if there isn't one already
 # See the website https://www.itwissen.info/MAC-Adresse-MAC-address.html
@@ -41,6 +42,7 @@ done
 uci set tunneldigger.$IFACE.uuid=$UUID
 uci set tunneldigger.$IFACE.interface=$IFACE
 uci set tunneldigger.$IFACE.broker_selection=usage
+uci set tunneldigger.$IFACE.bind_interface=$BIND
 uci set tunneldigger.$IFACE.enabled=1
 
 # network setup

--- a/addons/freifunk-berlin-tunneldigger/Makefile
+++ b/addons/freifunk-berlin-tunneldigger/Makefile
@@ -44,14 +44,4 @@ define Package/freifunk-berlin-tunneldigger/conffiles
 /etc/config/tunneldigger
 endef
 
-define Package/freifunk-berlin-tunneldigger/postinst
-#!/bin/sh
-# Do not enable the init script and rely on the hotplug script to
-# start and stop tunneldigger.  The init script is there to
-# make it easier for the user to run 
-#      /etc/init.d/tunneldigger {start|stop|restart}
-[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/tunneldigger disable
-exit 0
-endef
-
 $(eval $(call BuildPackage,freifunk-berlin-tunneldigger))

--- a/addons/freifunk-berlin-tunneldigger/Makefile
+++ b/addons/freifunk-berlin-tunneldigger/Makefile
@@ -1,0 +1,57 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=freifunk-berlin-tunneldigger
+PKG_RELEASE:=1
+
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=git://github.com/wlanslovenija/tunneldigger.git
+PKG_SOURCE_DATE:=2017-12-13
+PKG_SOURCE_VERSION:=d7db350011076d6a83855d412885a29a7d142b6e
+
+include $(INCLUDE_DIR)/package.mk
+include $(INCLUDE_DIR)/cmake.mk
+
+define Package/freifunk-berlin-tunneldigger
+  SECTION:=net
+  CATEGORY:=Network
+  DEPENDS:=+libnl-tiny +kmod-l2tp +kmod-l2tp-ip +kmod-l2tp-eth +librt +libpthread
+  TITLE:=L2TPv3 tunnel broker client
+  PROVIDES:=tunneldigger
+endef
+
+TARGET_CFLAGS += \
+	-I$(STAGING_DIR)/usr/include/libnl-tiny \
+	-I$(STAGING_DIR)/usr/include \
+	-DLIBNL_TINY
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(CP) $(PKG_BUILD_DIR)/client/* $(PKG_BUILD_DIR)
+endef
+
+define Package/freifunk-berlin-tunneldigger/install
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/tunneldigger $(1)/usr/bin/tunneldigger
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/tunneldigger.init $(1)/etc/init.d/tunneldigger
+	$(INSTALL_DIR) $(1)/etc/hotplug.d/iface
+	$(INSTALL_BIN) ./files/tunneldigger.hotplug $(1)/etc/hotplug.d/iface/60-tunneldigger
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/config.default $(1)/etc/config/tunneldigger
+endef
+
+define Package/freifunk-berlin-tunneldigger/conffiles
+/etc/config/tunneldigger
+endef
+
+define Package/freifunk-berlin-tunneldigger/postinst
+#!/bin/sh
+# Do not enable the init script and rely on the hotplug script to
+# start and stop tunneldigger.  The init script is there to
+# make it easier for the user to run 
+#      /etc/init.d/tunneldigger {start|stop|restart}
+[ -z "$${IPKG_INSTROOT}" ] && /etc/init.d/tunneldigger disable
+exit 0
+endef
+
+$(eval $(call BuildPackage,freifunk-berlin-tunneldigger))

--- a/addons/freifunk-berlin-tunneldigger/files/config.default
+++ b/addons/freifunk-berlin-tunneldigger/files/config.default
@@ -1,0 +1,10 @@
+config broker
+	list address 'x.y.z.w:8942'
+	list address 'x.y.z.w:53'
+	list address 'x.y.z.w:123'
+	option uuid 'abcd'
+	option group 'root'
+	option interface 'l2tp0'
+	option limit_bw_down '1024'
+	option broker_selection 'usage'
+	option enabled '0'

--- a/addons/freifunk-berlin-tunneldigger/files/tunneldigger.hotplug
+++ b/addons/freifunk-berlin-tunneldigger/files/tunneldigger.hotplug
@@ -1,0 +1,141 @@
+#!/bin/sh 
+
+. /lib/functions.sh
+. /lib/functions/network.sh
+
+PIDPATH=/var/run
+tunnel_id=0
+
+tunnel_is_up() {
+        local iface=$1
+        local pidfile="${PIDPATH}/tunneldigger.${iface}.pid"
+        local pid=0
+        local result=0
+
+        [ -e ${pidfile} ] && pid="$(cat ${pidfile})"
+        [ ${pid} != 0 ] && [ -d "/proc/${pid}" ] && result=1
+        echo "${result}"
+}
+
+interface_disabled() {
+        local iface=$1
+        local disabled=$(uci -q get network.${iface}.disabled)
+        [ -z $disabled ] && disabled=0
+        echo "${disabled}"
+}
+
+missing() {
+	logger -t td-client "Not starting tunneldigger \"$1\" - missing $2" >&2
+}
+
+handle_td_ifup() {
+	local cfg=$1
+	local enabled
+	local addresses
+	local uuid
+	local interface
+	local group
+	local limit_bw_down
+	local hook_script
+	local bind_interface
+	local broker_selection
+
+	config_get_bool enabled "$cfg" enabled 1
+	config_get addresses "$cfg" address
+	config_get uuid "$cfg" uuid
+	config_get interface "$cfg" interface
+	config_get group "$cfg" group
+	config_get limit_bw_down "$cfg" limit_bw_down
+	config_get hook_script "$cfg" hook_script
+	config_get bind_interface "$cfg" bind_interface
+	config_get broker_selection "$cfg" broker_selection
+
+	let tunnel_id++
+
+	[ $enabled -eq 0 ] && return
+        [ ! -z ${bind_interface} ] && \
+                [ "$INTERFACE" != "${bind_interface}" ] && \
+		[ "$INTERFACE" != "${interface}" ] && return
+	[ $(interface_disabled ${interface}) == "1" ] && \
+		logger -t td-client "Not starting tunneldiger \"${cfg}\", interface ${interface} disabled" && return
+	[ $(tunnel_is_up ${interface}) == "1" ] && return
+
+	local broker_opts=""
+	local address
+	for address in $addresses; do
+		append broker_opts "-b ${address}"
+	done
+
+	[ ! -z "${limit_bw_down}" ] && append broker_opts "-L ${limit_bw_down}"
+	[ ! -z "${hook_script}" ] && append broker_opts "-s ${hook_script}"
+	[ ! -z "${bind_interface}" ] && {
+		# Resolve logical interface name.
+		unset _bind_interface
+		network_get_device _bind_interface "${bind_interface}" || _bind_interface="${bind_interface}"
+		append broker_opts "-I ${_bind_interface}"
+	}
+	[ ! -z "${broker_selection}" ] && {
+		# Set broker selection.
+		case "${broker_selection}" in
+			usage)
+				append broker_opts "-a"
+			;;
+			first)
+				append broker_opts "-g"
+			;;
+			random)
+				append broker_opts "-r"
+			;;
+		esac
+	}
+
+	if [ -z "$uuid" ]; then
+		missing $cfg uuid
+		return
+	elif [ -z "$interface" ]; then
+		missing $cfg interface
+		return
+	fi
+
+	logger -t td-client "Starting tunneldigger \"$cfg\" on ${interface}"
+	/sbin/start-stop-daemon -S -q -b -m -c root:${group} -p ${PIDPATH}/tunneldigger.${interface}.pid -x /usr/bin/tunneldigger -- -u ${uuid} -i ${interface} -t ${tunnel_id} ${broker_opts}
+}
+
+handle_td_ifdown() {
+	local cfg=$1
+	local interface
+	local bind_interface
+
+	config_get interface "$cfg" interface
+	config_get bind_interface "$cfg" bind_interface
+
+	[ -z ${bind_interface} ] && [ "$INTERFACE" != "$interface" ] && \
+		return
+
+	[ ! -z  ${bind_interface} ] && [ "$INTERFACE" != "${bind_interface}" ] && \
+		return
+
+	[ $(tunnel_is_up ${interface}) != "1" ] && return
+
+	local PIDFILE=${PIDPATH}/tunneldigger.${interface}.pid
+	local PID="$(cat ${PIDFILE})"
+	logger -t td-client "Stopping tunneldigger \"$cfg\" on ${interface} PIDFILE=${PIDFILE}"
+	/sbin/start-stop-daemon -K -q -p $PIDFILE 
+	while test -d "/proc/${PID}"; do 
+		logger -t td-client "  waiting for tunneldigger to stop" 
+		sleep 1 
+	done
+	$(rm -f ${PIDFILE})
+	logger -t td-client "  tunneldigger stopped" 
+}
+
+config_load tunneldigger
+if [ "$ACTION" = ifup ]; then
+	config_foreach handle_td_ifup broker
+fi
+
+if [ "$ACTION" = ifdown ]; then
+	config_foreach handle_td_ifdown broker
+fi
+
+

--- a/addons/freifunk-berlin-tunneldigger/files/tunneldigger.hotplug
+++ b/addons/freifunk-berlin-tunneldigger/files/tunneldigger.hotplug
@@ -25,117 +25,117 @@ interface_disabled() {
 }
 
 missing() {
-	logger -t td-client "Not starting tunneldigger \"$1\" - missing $2" >&2
+        logger -t td-client "Not starting tunneldigger \"$1\" - missing $2" >&2
 }
 
 handle_td_ifup() {
-	local cfg=$1
-	local enabled
-	local addresses
-	local uuid
-	local interface
-	local group
-	local limit_bw_down
-	local hook_script
-	local bind_interface
-	local broker_selection
+        local cfg=$1
+        local enabled
+        local addresses
+        local uuid
+        local interface
+        local group
+        local limit_bw_down
+        local hook_script
+        local bind_interface
+        local broker_selection
 
-	config_get_bool enabled "$cfg" enabled 1
-	config_get addresses "$cfg" address
-	config_get uuid "$cfg" uuid
-	config_get interface "$cfg" interface
-	config_get group "$cfg" group
-	config_get limit_bw_down "$cfg" limit_bw_down
-	config_get hook_script "$cfg" hook_script
-	config_get bind_interface "$cfg" bind_interface
-	config_get broker_selection "$cfg" broker_selection
+        config_get_bool enabled "$cfg" enabled 1
+        config_get addresses "$cfg" address
+        config_get uuid "$cfg" uuid
+        config_get interface "$cfg" interface
+        config_get group "$cfg" group
+        config_get limit_bw_down "$cfg" limit_bw_down
+        config_get hook_script "$cfg" hook_script
+        config_get bind_interface "$cfg" bind_interface
+        config_get broker_selection "$cfg" broker_selection
 
-	let tunnel_id++
+        let tunnel_id++
 
-	[ $enabled -eq 0 ] && return
+        [ $enabled -eq 0 ] && return
         [ ! -z ${bind_interface} ] && \
                 [ "$INTERFACE" != "${bind_interface}" ] && \
-		[ "$INTERFACE" != "${interface}" ] && return
-	[ $(interface_disabled ${interface}) == "1" ] && \
-		logger -t td-client "Not starting tunneldiger \"${cfg}\", interface ${interface} disabled" && return
-	[ $(tunnel_is_up ${interface}) == "1" ] && return
+                [ "$INTERFACE" != "${interface}" ] && return
+        [ $(interface_disabled ${interface}) == "1" ] && \
+                logger -t td-client "Not starting tunneldiger \"${cfg}\", interface ${interface} disabled" && return
+        [ $(tunnel_is_up ${interface}) == "1" ] && return
 
-	local broker_opts=""
-	local address
-	for address in $addresses; do
-		append broker_opts "-b ${address}"
-	done
+        local broker_opts=""
+        local address
+        for address in $addresses; do
+                append broker_opts "-b ${address}"
+        done
 
-	[ ! -z "${limit_bw_down}" ] && append broker_opts "-L ${limit_bw_down}"
-	[ ! -z "${hook_script}" ] && append broker_opts "-s ${hook_script}"
-	[ ! -z "${bind_interface}" ] && {
-		# Resolve logical interface name.
-		unset _bind_interface
-		network_get_device _bind_interface "${bind_interface}" || _bind_interface="${bind_interface}"
-		append broker_opts "-I ${_bind_interface}"
-	}
-	[ ! -z "${broker_selection}" ] && {
-		# Set broker selection.
-		case "${broker_selection}" in
-			usage)
-				append broker_opts "-a"
-			;;
-			first)
-				append broker_opts "-g"
-			;;
-			random)
-				append broker_opts "-r"
-			;;
-		esac
-	}
+        [ ! -z "${limit_bw_down}" ] && append broker_opts "-L ${limit_bw_down}"
+        [ ! -z "${hook_script}" ] && append broker_opts "-s ${hook_script}"
+        [ ! -z "${bind_interface}" ] && {
+                # Resolve logical interface name.
+                unset _bind_interface
+                network_get_device _bind_interface "${bind_interface}" || _bind_interface="${bind_interface}"
+                append broker_opts "-I ${_bind_interface}"
+        }
+        [ ! -z "${broker_selection}" ] && {
+                # Set broker selection.
+                case "${broker_selection}" in
+                        usage)
+                                append broker_opts "-a"
+                        ;;
+                        first)
+                                append broker_opts "-g"
+                        ;;
+                        random)
+                                append broker_opts "-r"
+                        ;;
+                esac
+        }
 
-	if [ -z "$uuid" ]; then
-		missing $cfg uuid
-		return
-	elif [ -z "$interface" ]; then
-		missing $cfg interface
-		return
-	fi
+        if [ -z "$uuid" ]; then
+                missing $cfg uuid
+                return
+        elif [ -z "$interface" ]; then
+                missing $cfg interface
+                return
+        fi
 
-	logger -t td-client "Starting tunneldigger \"$cfg\" on ${interface}"
-	/sbin/start-stop-daemon -S -q -b -m -c root:${group} -p ${PIDPATH}/tunneldigger.${interface}.pid -x /usr/bin/tunneldigger -- -u ${uuid} -i ${interface} -t ${tunnel_id} ${broker_opts}
+        logger -t td-client "Starting tunneldigger \"$cfg\" on ${interface}"
+        /sbin/start-stop-daemon -S -q -b -m -c root:${group} -p ${PIDPATH}/tunneldigger.${interface}.pid -x /usr/bin/tunneldigger -- -u ${uuid} -i ${interface} -t ${tunnel_id} ${broker_opts}
 }
 
 handle_td_ifdown() {
-	local cfg=$1
-	local interface
-	local bind_interface
+        local cfg=$1
+        local interface
+        local bind_interface
 
-	config_get interface "$cfg" interface
-	config_get bind_interface "$cfg" bind_interface
+        config_get interface "$cfg" interface
+        config_get bind_interface "$cfg" bind_interface
 
-	[ -z ${bind_interface} ] && [ "$INTERFACE" != "$interface" ] && \
-		return
+        [ -z ${bind_interface} ] && [ "$INTERFACE" != "$interface" ] && \
+                return
 
-	[ ! -z  ${bind_interface} ] && [ "$INTERFACE" != "${bind_interface}" ] && \
-		return
+        [ ! -z  ${bind_interface} ] && [ "$INTERFACE" != "${bind_interface}" ] && \
+                return
 
-	[ $(tunnel_is_up ${interface}) != "1" ] && return
+        [ $(tunnel_is_up ${interface}) != "1" ] && return
 
-	local PIDFILE=${PIDPATH}/tunneldigger.${interface}.pid
-	local PID="$(cat ${PIDFILE})"
-	logger -t td-client "Stopping tunneldigger \"$cfg\" on ${interface} PIDFILE=${PIDFILE}"
-	/sbin/start-stop-daemon -K -q -p $PIDFILE 
-	while test -d "/proc/${PID}"; do 
-		logger -t td-client "  waiting for tunneldigger to stop" 
-		sleep 1 
-	done
-	$(rm -f ${PIDFILE})
-	logger -t td-client "  tunneldigger stopped" 
+        local PIDFILE=${PIDPATH}/tunneldigger.${interface}.pid
+        local PID="$(cat ${PIDFILE})"
+        logger -t td-client "Stopping tunneldigger \"$cfg\" on ${interface} PIDFILE=${PIDFILE}"
+        /sbin/start-stop-daemon -K -q -p $PIDFILE 
+        while test -d "/proc/${PID}"; do 
+                logger -t td-client "  waiting for tunneldigger to stop" 
+                sleep 1 
+        done
+        $(rm -f ${PIDFILE})
+        logger -t td-client "  tunneldigger stopped" 
 }
 
 config_load tunneldigger
 if [ "$ACTION" = ifup ]; then
-	config_foreach handle_td_ifup broker
+        config_foreach handle_td_ifup broker
 fi
 
 if [ "$ACTION" = ifdown ]; then
-	config_foreach handle_td_ifdown broker
+        config_foreach handle_td_ifdown broker
 fi
 
 

--- a/addons/freifunk-berlin-tunneldigger/files/tunneldigger.init
+++ b/addons/freifunk-berlin-tunneldigger/files/tunneldigger.init
@@ -1,0 +1,122 @@
+#!/bin/sh /etc/rc.common
+
+. $IPKG_INSTROOT/lib/functions/network.sh
+
+START=90
+
+PIDPATH=/var/run
+tunnel_id=0
+
+tunnel_is_up() {
+        local iface=$1
+        local pidfile="${PIDPATH}/tunneldigger.${iface}.pid"
+	local pid=0
+	local result=0
+
+        [ -e ${pidfile} ] && pid="$(cat ${pidfile})"
+	[ ${pid} != 0 ] && [ -d "/proc/${pid}" ] && result=1
+        echo "${result}"
+}
+
+interface_disabled() {
+        local iface=$1
+        local disabled=$(uci -q get network.${iface}.disabled)
+        [ -z $disabled ] && disabled=0
+        echo "${disabled}"
+}
+ 
+missing() {
+	echo "Not starting tunneldigger \"$1\" - missing $2" >&2
+}
+
+handle_td() {
+	local cfg=$1
+	local enabled
+	local addresses
+	local uuid
+	local interface
+	local group
+	local limit_bw_down
+	local hook_script
+	local bind_interface
+	local broker_selection
+
+
+	config_get_bool enabled "$cfg" enabled 1
+	config_get addresses "$cfg" address
+	config_get uuid "$cfg" uuid
+	config_get interface "$cfg" interface
+	config_get group "$cfg" group
+	config_get limit_bw_down "$cfg" limit_bw_down
+	config_get hook_script "$cfg" hook_script
+	config_get bind_interface "$cfg" bind_interface
+	config_get broker_selection "$cfg" broker_selection
+
+	let tunnel_id++
+			
+	[ $enabled -eq 0 ] && return
+	[ $(interface_disabled ${interface}) == "1" ] && \
+		echo "Not starting tunneldigger \"${cfg}\", interface ${interface} disabled" && return
+	[ $(tunnel_is_up ${interface}) == "1" ] && \
+		echo "Not starting tunneldigger \"${cfg}\", already started" && return
+
+	local broker_opts=""
+	local address
+	for address in $addresses; do
+		append broker_opts "-b ${address}"
+	done
+
+	[ ! -z "${limit_bw_down}" ] && append broker_opts "-L ${limit_bw_down}"
+	[ ! -z "${hook_script}" ] && append broker_opts "-s ${hook_script}"
+	[ ! -z "${broker_selection}" ] && {
+		# Set broker selection.
+		case "${broker_selection}" in
+			usage)
+				append broker_opts "-a"
+			;;
+			first)
+				append broker_opts "-g"
+			;;
+			random)
+				append broker_opts "-r"
+			;;
+		esac
+	}
+
+	if [ -z "$uuid" ]; then
+		missing $cfg uuid
+		return
+	elif [ -z "$interface" ]; then
+		missing $cfg interface
+		return
+	fi
+
+	echo "Starting tunneldigger \"$cfg\" on ${interface}"
+	/sbin/start-stop-daemon -S -q -b -m -c root:${group} -p ${PIDPATH}/tunneldigger.${interface}.pid -x /usr/bin/tunneldigger -- -u ${uuid} -i ${interface} -t ${tunnel_id} ${broker_opts}
+}
+
+start() {
+	config_load tunneldigger
+	config_foreach handle_td broker
+}
+
+stop() {
+	for PIDFILE in `find ${PIDPATH}/ -name "tunneldigger\.*\.pid"`; do
+		PID="$(cat ${PIDFILE})"
+		IFACE="$(echo ${PIDFILE} | awk -F\/tunneldigger '{print $2}' | cut -d'.' -f2)"
+		echo "Stopping tunneldigger for interface ${IFACE}"
+		start-stop-daemon -K -q -p $PIDFILE 
+		while test -d "/proc/${PID}"; do
+			echo "  waiting for tunneldigger to stop"
+			sleep 1
+		done
+		$(rm -f ${PIDFILE})
+		echo "  tunneldigger stopped"
+	done
+}
+
+restart() {
+	stop
+	start
+}
+

--- a/addons/freifunk-berlin-tunneldigger/files/tunneldigger.init
+++ b/addons/freifunk-berlin-tunneldigger/files/tunneldigger.init
@@ -2,7 +2,10 @@
 
 . $IPKG_INSTROOT/lib/functions/network.sh
 
-START=90
+# Comment out the START declaration to prevent the init file from
+# actually starting tunneldigger at startup.  Instead rely on the
+# hotplug scripts
+#START=90
 
 PIDPATH=/var/run
 tunnel_id=0

--- a/addons/freifunk-berlin-tunneldigger/files/tunneldigger.init
+++ b/addons/freifunk-berlin-tunneldigger/files/tunneldigger.init
@@ -13,11 +13,11 @@ tunnel_id=0
 tunnel_is_up() {
         local iface=$1
         local pidfile="${PIDPATH}/tunneldigger.${iface}.pid"
-	local pid=0
-	local result=0
+        local pid=0
+        local result=0
 
         [ -e ${pidfile} ] && pid="$(cat ${pidfile})"
-	[ ${pid} != 0 ] && [ -d "/proc/${pid}" ] && result=1
+        [ ${pid} != 0 ] && [ -d "/proc/${pid}" ] && result=1
         echo "${result}"
 }
 
@@ -29,97 +29,96 @@ interface_disabled() {
 }
  
 missing() {
-	echo "Not starting tunneldigger \"$1\" - missing $2" >&2
+        echo "Not starting tunneldigger \"$1\" - missing $2" >&2
 }
 
 handle_td() {
-	local cfg=$1
-	local enabled
-	local addresses
-	local uuid
-	local interface
-	local group
-	local limit_bw_down
-	local hook_script
-	local bind_interface
-	local broker_selection
+        local cfg=$1
+        local enabled
+        local addresses
+        local uuid
+        local interface
+        local group
+        local limit_bw_down
+        local hook_script
+        local bind_interface
+        local broker_selection
 
+        config_get_bool enabled "$cfg" enabled 1
+        config_get addresses "$cfg" address
+        config_get uuid "$cfg" uuid
+        config_get interface "$cfg" interface
+        config_get group "$cfg" group
+        config_get limit_bw_down "$cfg" limit_bw_down
+        config_get hook_script "$cfg" hook_script
+        config_get bind_interface "$cfg" bind_interface
+        config_get broker_selection "$cfg" broker_selection
 
-	config_get_bool enabled "$cfg" enabled 1
-	config_get addresses "$cfg" address
-	config_get uuid "$cfg" uuid
-	config_get interface "$cfg" interface
-	config_get group "$cfg" group
-	config_get limit_bw_down "$cfg" limit_bw_down
-	config_get hook_script "$cfg" hook_script
-	config_get bind_interface "$cfg" bind_interface
-	config_get broker_selection "$cfg" broker_selection
-
-	let tunnel_id++
+        let tunnel_id++
 			
-	[ $enabled -eq 0 ] && return
-	[ $(interface_disabled ${interface}) == "1" ] && \
-		echo "Not starting tunneldigger \"${cfg}\", interface ${interface} disabled" && return
-	[ $(tunnel_is_up ${interface}) == "1" ] && \
-		echo "Not starting tunneldigger \"${cfg}\", already started" && return
+        [ $enabled -eq 0 ] && return
+        [ $(interface_disabled ${interface}) == "1" ] && \
+                echo "Not starting tunneldigger \"${cfg}\", interface ${interface} disabled" && return
+        [ $(tunnel_is_up ${interface}) == "1" ] && \
+                echo "Not starting tunneldigger \"${cfg}\", already started" && return
 
-	local broker_opts=""
-	local address
-	for address in $addresses; do
-		append broker_opts "-b ${address}"
-	done
+        local broker_opts=""
+        local address
+        for address in $addresses; do
+                append broker_opts "-b ${address}"
+        done
 
-	[ ! -z "${limit_bw_down}" ] && append broker_opts "-L ${limit_bw_down}"
-	[ ! -z "${hook_script}" ] && append broker_opts "-s ${hook_script}"
-	[ ! -z "${broker_selection}" ] && {
-		# Set broker selection.
-		case "${broker_selection}" in
-			usage)
-				append broker_opts "-a"
-			;;
-			first)
-				append broker_opts "-g"
-			;;
-			random)
-				append broker_opts "-r"
-			;;
-		esac
-	}
+        [ ! -z "${limit_bw_down}" ] && append broker_opts "-L ${limit_bw_down}"
+        [ ! -z "${hook_script}" ] && append broker_opts "-s ${hook_script}"
+        [ ! -z "${broker_selection}" ] && {
+                # Set broker selection.
+                case "${broker_selection}" in
+                        usage)
+                                append broker_opts "-a"
+                        ;;
+                        first)
+                                append broker_opts "-g"
+                        ;;
+                        random)
+                                append broker_opts "-r"
+                        ;;
+                esac
+        }
 
-	if [ -z "$uuid" ]; then
-		missing $cfg uuid
-		return
-	elif [ -z "$interface" ]; then
-		missing $cfg interface
-		return
-	fi
+        if [ -z "$uuid" ]; then
+                missing $cfg uuid
+                return
+        elif [ -z "$interface" ]; then
+                missing $cfg interface
+                return
+        fi
 
-	echo "Starting tunneldigger \"$cfg\" on ${interface}"
-	/sbin/start-stop-daemon -S -q -b -m -c root:${group} -p ${PIDPATH}/tunneldigger.${interface}.pid -x /usr/bin/tunneldigger -- -u ${uuid} -i ${interface} -t ${tunnel_id} ${broker_opts}
+        echo "Starting tunneldigger \"$cfg\" on ${interface}"
+        /sbin/start-stop-daemon -S -q -b -m -c root:${group} -p ${PIDPATH}/tunneldigger.${interface}.pid -x /usr/bin/tunneldigger -- -u ${uuid} -i ${interface} -t ${tunnel_id} ${broker_opts}
 }
 
 start() {
-	config_load tunneldigger
-	config_foreach handle_td broker
+        config_load tunneldigger
+        config_foreach handle_td broker
 }
 
 stop() {
-	for PIDFILE in `find ${PIDPATH}/ -name "tunneldigger\.*\.pid"`; do
-		PID="$(cat ${PIDFILE})"
-		IFACE="$(echo ${PIDFILE} | awk -F\/tunneldigger '{print $2}' | cut -d'.' -f2)"
-		echo "Stopping tunneldigger for interface ${IFACE}"
-		start-stop-daemon -K -q -p $PIDFILE 
-		while test -d "/proc/${PID}"; do
-			echo "  waiting for tunneldigger to stop"
-			sleep 1
-		done
-		$(rm -f ${PIDFILE})
-		echo "  tunneldigger stopped"
-	done
+        for PIDFILE in `find ${PIDPATH}/ -name "tunneldigger\.*\.pid"`; do
+                PID="$(cat ${PIDFILE})"
+                IFACE="$(echo ${PIDFILE} | awk -F\/tunneldigger '{print $2}' | cut -d'.' -f2)"
+                echo "Stopping tunneldigger for interface ${IFACE}"
+                start-stop-daemon -K -q -p $PIDFILE 
+                while test -d "/proc/${PID}"; do
+                        echo "  waiting for tunneldigger to stop"
+                        sleep 1
+                done
+                $(rm -f ${PIDFILE})
+                echo "  tunneldigger stopped"
+        done
 }
 
 restart() {
-	stop
-	start
+        stop
+        start
 }
 

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/Makefile
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-tunnelberlin-tunneldigger-files
-PKG_VERSION:=0.0.4
+PKG_VERSION:=0.0.5
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
@@ -14,7 +14,7 @@ define Package/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files
   CATEGORY:=freifunk-berlin
   TITLE:=Freifunk Berlin Networktunnel files
   URL:=http://github.com/freifunk-berlin/firmware-packages
-  DEPENDS+= +freifunk-berlin-lib-guard +tunneldigger
+  DEPENDS+= +freifunk-berlin-lib-guard +freifunk-berlin-tunneldigger
   PROVIDES:=freifunk-berlin-uplink
   PKGARCH:=all
 endef

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-tunneldigger
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-tunneldigger
@@ -57,6 +57,7 @@ done
 uci set tunneldigger.ffuplink.uuid=$UUID
 uci set tunneldigger.ffuplink.interface=ffuplink
 uci set tunneldigger.ffuplink.broker_selection=usage
+uci set tunneldigger.ffuplink.bind_interface=wan
 uci set tunneldigger.ffuplink.enabled=1
 uci commit tunneldigger
 


### PR DESCRIPTION
Create the freifunk-berlin-tunneldigger package

This package is based on the gluon tunneldigger package.
https://github.com/freifunk-gluon/packages/tree/master/net/tunneldigger

The source for the tunneldigger client is at
https://github.com/wlanslovenija/tunneldigger

The differences to the gluon version are:
* The init script is disabled by default
* Fixed problems with starting multiple tunneldigger instances
* Added a hotplug script which waits for the bind_interface to go up/down before starting/stopping any associated tunneldigger
* Does not start tunneldigger for an interface if the interface is disabled
* Does not start tunneldigger if it has already been started
* Removes pid files when tunneldigger is stopped

Additionally all changes to uplink-tunnelberlin-tunneldigger and bbbdigger have been included

The init script is disabled in the luci wizard when tunneldigger is installed in the image.  If tunneldigger is installed via opkg (for example with bbbdigger) then the init script is disabled with the postinst script