### PR TITLE
Openwrt 19x: luci-master: add new dependency to luci-lib-ipkg

### DIFF
--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ffwizard-berlin
 PKG_VERSION:=0.0.16
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -16,7 +16,7 @@ define Package/luci-app-ffwizard-berlin
   SUBMENU:=3. Applications
   TITLE:=Freifunk Berlin configuration wizard
   URL:=http://berlin.freifunk.net
-  DEPENDS+= +luci-mod-admin-full +freifunk-policyrouting +luci-lib-jsonc +community-profiles
+  DEPENDS+= +luci-mod-admin-full +freifunk-policyrouting +luci-lib-jsonc +community-profiles +luci-lib-ipkg
   PKGARCH:=all
 endef
 

--- a/utils/luci-mod-freifunk-ui/Makefile
+++ b/utils/luci-mod-freifunk-ui/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-mod-freifunk-ui
 PKG_VERSION:=0.0.4
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -20,7 +20,7 @@ define Package/luci-mod-freifunk-ui
   CATEGORY:=LuCI
   SUBMENU:=2. Modules
   TITLE:=Freifunk Public and Admin LuCI UI
-  DEPENDS:=+luci-mod-admin-full +luci-lib-json +community-profiles
+  DEPENDS:=+luci-mod-admin-full +luci-lib-json +community-profiles +luci-lib-ipkg
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
**Do not merge before the firmware is based off of OpenWRT 19.x**

This is specific for the luci-master branch

This became an issue because the luci-lib-ipkg code has been
removed from luci-base.  The upstream commit is
https://github.com/openwrt/luci/commit/4bbe32548c407ec6ae104934b3f1fe53539de9f6