### PR TITLE
uplink tunnel-berlin: set auth-type for tunneldigger

### DIFF
--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-tunneldigger
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-tunneldigger
@@ -13,6 +13,9 @@ if [[ $(uci get ffberlin-uplink.preset.current) != "tunnelberlin_tunneldigger" ]
   uci rename ffberlin-uplink.preset.current=previous
   uci set ffberlin-uplink.preset.current="tunnelberlin_tunneldigger"
 fi
+# set set auth-type required for this uplink-type, e.g. for freifunk-wizard
+uci set ffberlin-uplink.uplink=settings
+uci set ffberlin-uplink.uplink.auth=none
 uci commit ffberlin-uplink
 
 . /lib/functions/guard.sh


### PR DESCRIPTION
As we don't need any authentication for the tunneldigger uplink, set "ffberlin-uplink.uplink.auth=none"

With this setting the wizard will not ask for x509 certs.