### PR TITLE
disassoc_low_ack causes problems with clients so disable

### DIFF
--- a/utils/freifunk-berlin-wizard-backend/files/usr/lib/ffwizard.d/15-wireless.sh
+++ b/utils/freifunk-berlin-wizard-backend/files/usr/lib/ffwizard.d/15-wireless.sh
@@ -159,6 +159,7 @@ setup_wireless() {
     uci set wireless.$iface.ifname="wlan${idx}-dhcp"
     uci set wireless.$iface.ssid="berlin.freifunk.net"
     uci set wireless.$iface.mcast_rate=6000
+    uci set wireless.$iface.disassoc_low_ack=0
 
     idx=$((idx+1))
   done


### PR DESCRIPTION
* Clients can not connect
* Clients get disconnected after seconds

Related to:
https://github.com/freifunk-berlin/firmware/issues/635

