### PR TITLE
uplink notunnel: ensure proper macaddr generation

### DIFF
--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-z95_notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-z95_notunnel
@@ -29,6 +29,13 @@ uci set network.ffuplink_dev=device
 uci set network.ffuplink_dev.type=veth
 uci set network.ffuplink_dev.name=ffuplink
 uci set network.ffuplink_dev.peer_name=ffuplink_wan
+# Create a static macaddr starting with "fe" for ffuplink devices
+# See the website https://www.itwissen.info/MAC-Adresse-MAC-address.html
+macaddr="fe"
+for byte in 2 3 4 5 6; do
+  macaddr=$macaddr`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
+done
+uci set network.ffuplink_dev.macaddr=$macaddr
 # add ffuplink_dev to br-wan if not there
 ifnames=$(uci get network.wan.ifname)
 list_contains ifnames ffuplink_wan || uci set network.wan.ifname="${ifnames} ffuplink_wan"

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-z95_notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-z95_notunnel
@@ -7,13 +7,13 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-if [ $(uci get ffberlin-uplink.preset.current) != "no-tunnel" ]; then
+if [ $(uci get ffberlin-uplink.preset.current) != "notunnel" ]; then
   logger -t "ffuplink" "uplink-preset has been changed."
   # do not track preset when it was 'undefined', aka never configured
   if [ $(uci get ffberlin-uplink.preset.current) != 'undefined' ]; then
     uci rename ffberlin-uplink.preset.current=previous
   fi
-  uci set ffberlin-uplink.preset.current="no-tunnel"
+  uci set ffberlin-uplink.preset.current="notunnel"
 fi
 # set set auth-type required for this uplink-type, e.g. for freifunk-wizard
 uci set ffberlin-uplink.uplink=settings


### PR DESCRIPTION
Removed these changes from the for-Hedy-1.0.x_tunneldigger branch and made it in a seperate branch for easier and clearer migration