### PR TITLE
uplink macddr: store the macaddr of ffuplink_dev in ffberlin-uplink

### DIFF
--- a/defaults/freifunk-berlin-network-defaults/lib/functions/freifunk-berlin-network.sh
+++ b/defaults/freifunk-berlin-network-defaults/lib/functions/freifunk-berlin-network.sh
@@ -21,3 +21,17 @@ create_ffuplink() {
   guard_delete tunnelberlin_tunneldigger
   guard_delete vpn03_openvpn
 }
+
+generate_random_mac_hex() {
+  local prefix=$1
+
+  [ -n "$prefix" ] || return
+  local macaddr
+  # Create a static macaddr starting with "prefix" for ffuplink devices
+  # See the website https://www.itwissen.info/MAC-Adresse-MAC-address.html
+  for byte in 2 3 4 5 6; do
+    macaddr=$macaddr`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
+  done
+
+  echo $prefix$macaddr
+}

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-z95_notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-z95_notunnel
@@ -22,12 +22,7 @@ uci set ffberlin-uplink.uplink.auth=none
 
 macaddr=$(uci -q get ffberlin-uplink.uplink.macaddr)
 if [[ -z $macaddr ]]; then
-  # Create a static macaddr starting with "fe" for ffuplink devices
-  # See the website https://www.itwissen.info/MAC-Adresse-MAC-address.html
-  macaddr="fe"
-  for byte in 2 3 4 5 6; do
-    macaddr=$macaddr`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
-  done
+  macaddr=$(generate_random_mac_hex "fe")
   uci set ffberlin-uplink.uplink.macaddr=$macaddr
 fi
 

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-z95_notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-z95_notunnel
@@ -20,6 +20,17 @@ fi
 uci set ffberlin-uplink.uplink=settings
 uci set ffberlin-uplink.uplink.auth=none
 
+macaddr=$(uci -q get ffberlin-uplink.uplink.macaddr)
+if [[ -z $macaddr ]]; then
+  # Create a static macaddr starting with "fe" for ffuplink devices
+  # See the website https://www.itwissen.info/MAC-Adresse-MAC-address.html
+  macaddr="fe"
+  for byte in 2 3 4 5 6; do
+    macaddr=$macaddr`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
+  done
+  uci set ffberlin-uplink.uplink.macaddr=$macaddr
+fi
+
 uci commit ffberlin-uplink
 
 . /lib/functions/guard.sh
@@ -30,12 +41,6 @@ uci set network.ffuplink_dev=device
 uci set network.ffuplink_dev.type=veth
 uci set network.ffuplink_dev.name=ffuplink
 uci set network.ffuplink_dev.peer_name=ffuplink_wan
-# Create a static macaddr starting with "fe" for ffuplink devices
-# See the website https://www.itwissen.info/MAC-Adresse-MAC-address.html
-macaddr="fe"
-for byte in 2 3 4 5 6; do
-  macaddr=$macaddr`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
-done
 uci set network.ffuplink_dev.macaddr=$macaddr
 uci commit network.ffuplink_dev
 

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-tunneldigger
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-tunneldigger
@@ -27,12 +27,7 @@ uci set ffberlin-uplink.uplink.auth=none
 
 macaddr=$(uci -q get ffberlin-uplink.uplink.macaddr)
 if [[ -z $macaddr ]]; then
-  # Create a static macaddr starting with "fe" for ffuplink devices
-  # See the website https://www.itwissen.info/MAC-Adresse-MAC-address.html
-  macaddr="fe"
-  for byte in 2 3 4 5 6; do
-    macaddr=$macaddr`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
-  done
+  macaddr=$(generate_random_mac_hex "fe")
   uci set ffberlin-uplink.uplink.macaddr=$macaddr
 fi
 

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-tunneldigger
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-tunneldigger
@@ -24,6 +24,18 @@ fi
 # set set auth-type required for this uplink-type, e.g. for freifunk-wizard
 uci set ffberlin-uplink.uplink=settings
 uci set ffberlin-uplink.uplink.auth=none
+
+macaddr=$(uci -q get ffberlin-uplink.uplink.macaddr)
+if [[ -z $macaddr ]]; then
+  # Create a static macaddr starting with "fe" for ffuplink devices
+  # See the website https://www.itwissen.info/MAC-Adresse-MAC-address.html
+  macaddr="fe"
+  for byte in 2 3 4 5 6; do
+    macaddr=$macaddr`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
+  done
+  uci set ffberlin-uplink.uplink.macaddr=$macaddr
+fi
+
 uci commit ffberlin-uplink
 
 . /lib/functions/guard.sh
@@ -32,12 +44,6 @@ guard "tunnelberlin_tunneldigger"
 uci delete network.ffuplink_dev
 uci set network.ffuplink_dev=device
 uci set network.ffuplink_dev.name=ffuplink
-# Create a static macaddr starting with "fe" for ffuplink devices
-# See the website https://www.itwissen.info/MAC-Adresse-MAC-address.html
-macaddr="fe"
-for byte in 2 3 4 5 6; do
-  macaddr=$macaddr`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
-done
 uci set network.ffuplink_dev.macaddr=$macaddr
 uci commit network.ffuplink_dev
 


### PR DESCRIPTION
The macaddr is saved in ffberlin-uplink.uplink.macaddr.  In this was it
will also be reused when changing uplink types back to a type which
previously had a macaddr.  This is important for those who set up special
mac filtering on their uplink routers (for example guest network or static
DHCP leases).

Situation:
install no-tunnel
change to openvpn
change back to no-tunnel

This addresses issue https://github.com/freifunk-berlin/firmware/issues/639