### PR TITLE
migration: run jffs-cleanup as very last uci-default script

### DIFF
--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
-PKG_VERSION:=0.5.3
+PKG_VERSION:=0.6.0
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -526,9 +526,6 @@ migrate () {
   uci commit
 
   log "Migration done."
-
-  # delete any overlay config files duplicated from romfs by sysupgrade - saves JFFS2 space
-  cd /overlay/upper/etc/config/ && for i in *; do [ -f "$i" ] && if cmp -s "$i" "/rom/etc/config/$i"; then rm -f "$i"; fi; done;
 }
 
 migrate

--- a/utils/freifunk-berlin-migration/uci-defaults/zz_freifunk-berlin-migration-clean_jffs.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/zz_freifunk-berlin-migration-clean_jffs.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+# delete any overlay config files duplicated from romfs by sysupgrade - saves JFFS2 space
+cd /overlay/upper/etc/config/ && for i in *; do [ -f "$i" ] && if cmp -s "$i" "/rom/etc/config/$i"; then rm -f "$i"; fi; done;


### PR DESCRIPTION
move the clean up of possible duplicates of rom-files into a separate uci-default script, which will run as very last.
This prevents from problems caused by https://github.com/freifunk-berlin/firmware/issues/641, but keeps this functionality.

This was initially tested on the Hedy-1.0.x branch 