### PR TITLE
add OLSRd core dump garbage collectiong

### DIFF
--- a/defaults/freifunk-berlin-olsrd-defaults/Makefile
+++ b/defaults/freifunk-berlin-olsrd-defaults/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-olsrd-defaults
-PKG_VERSION:=0.0.4
+PKG_VERSION:=0.0.5
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/defaults/freifunk-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
+++ b/defaults/freifunk-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
@@ -145,3 +145,6 @@ test -d /etc/iproute2/ || mkdir -p /etc/iproute2/
 grep -q "111 olsr" $tables || echo "111 olsr" >> $tables
 grep -q "112 olsr-default" $tables || echo "112 olsr-default" >> $tables
 grep -q "113 olsr-tunnel" $tables || echo "113 olsr-tunnel" >> $tables
+
+# add core dump garbage collection (issue #642)
+echo "23 4 * * *    rm -f /tmp/olsrd*core" >> /etc/crontabs/root

--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
-PKG_VERSION:=0.5.0
+PKG_VERSION:=0.5.1
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -480,10 +480,6 @@ migrate () {
     guard "ffberlin_uplink"
   fi
 
-#  if semverLT ${OLD_VERSION} "1.1.0"; then
-#    r1_1_0_remove_olsrd_garbage_collection
-#  fi
-
   # overwrite version with the new version
   log "Setting new system version to ${VERSION}."
   uci set system.@system[0].version=${VERSION}


### PR DESCRIPTION
the OLSR daemon in the 1.0.x firmware dumps a core whenever it
crashes.  This can slowly kill a router as it runs out of memory.  For the
1.0.x firmwares, the function r1_0_2_add_olsrd_garbage_collection has been
added

the OLSR daemon for the 1.1.x firmware does not have this issue.  For 1.1.x
firwares, the function r1_1_0_remove_olsrd_garbage_collection to undo the
garbage collection.

The garbage collection is done as a cron job which runs daily at 00:00
0 0 * * *	rm -f /tmp/olsrd*core

This addresses issue https://github.com/freifunk-berlin/firmware/issues/642