### PR TITLE
fix non-functioning uci:get_all() call

### DIFF
--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
@@ -1,6 +1,7 @@
 local uci = require "luci.model.uci".cursor()
 local sys = require "luci.sys"
 local fs = require "nixio.fs"
+local tools = require "luci.tools.freifunk.assistent.tools"
 
 f = SimpleForm("ffwizward", "", "")
 f.submit = "Next"
@@ -89,7 +90,11 @@ function main.write(self, section, value)
   uci:set("freifunk", "contact", "location",location:formvalue(section))
 
   local selectedCommunity = community:formvalue(section) or "Freifunk"
-  uci:tset("freifunk", "community", uci:get_all("profile_"..selectedCommunity, "profile"))
+  local mergeList= {"profile_"..selectedCommunity}
+  local profileData = tools.getMergedConfig(mergeList, "community", "profile")
+  for key, val in pairs(profileData) do
+    uci:set("freifunk", "community", key, val)
+  end
   uci:set("freifunk", "community", "name", selectedCommunity)
 
   local latval

--- a/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/olsr.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/olsr.lua
@@ -22,15 +22,14 @@ end
 
 
 function configureOLSR()
+	local mergeList = {"freifunk", community}
 	-- olsr 4
-	local olsrbase = uci:get_all("freifunk", "olsrd") or {}
-	util.update(olsrbase, uci:get_all(community, "olsrd") or {})
-	uci:tset("olsrd", "olsrd", olsrbase)
+	local olsrbase = tools.getMergedConfig(mergeList, "defaults", "olsrd")
+	tools.mergeInto("olsrd", "olsrd", olsrbase)
 
 	-- olsr 6
-	local olsr6base = uci:get_all("freifunk", "olsrd6") or {}
-	util.update(olsr6base, uci:get_all(community, "olsrd6") or {})
-	uci:tset("olsrd6", "olsrd", olsr6base)
+	local olsr6base = tools.getMergedConfig(mergeList, "defaults", "olsrd6")
+	tools.mergeInto("olsrd6", "olsrd", olsr6base)
 
 	-- set HNA for olsr6
 	local ula_prefix = uci:get("network","globals","ula_prefix")
@@ -45,14 +44,8 @@ function configureOLSR()
 	end
 
   -- olsr 4 interface defaults
-  local olsrifbase = uci:get_all("freifunk", "olsr_interface") or {}
-  util.update(olsrifbase, uci:get_all(community, "olsr_interface") or {})
-  local s = uci:get_first("olsrd", "InterfaceDefaults")
-  if (s) then
-    uci:tset("olsrd", s, olsrifbase)
-  else
-    uci:section("olsrd", "InterfaceDefaults", nil, olsrifbase)
-  end
+  local olsrifbase = tools.getMergedConfig(mergeList, "defaults", "olsr_interface")
+  tools.mergeInto("olsrd", "InterfaceDefaults", olsrifbase)
 
   uci:save("olsrd")
   uci:save("olsrd6")

--- a/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/tools.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/tools.lua
@@ -102,3 +102,40 @@ end
 function logger(msg)
         sys.exec("logger -t ffwizard -p 5 '"..msg.."'")
 end
+
+--Merge the options of multiple config files into a table.
+--
+--configs: an array of strings, each representing a config file.  
+--  The order is important since  the first config file is read, 
+--  then the following.  Any options in the following config files
+--  overwrite the values of any previous config files. 
+--  e.g. {"freifunk", "profile_berlin"}
+--sectionType: the section type to merge. e.g. "defaults"
+--sectionName: the section to merge. e.g. "olsrd"
+function getMergedConfig(configs, sectionType, sectionName)
+  local data = {}
+  for i, config in ipairs(configs) do
+    uci:foreach(config, sectionType,
+      function(s)
+        if s['.name'] == sectionName then
+          for key, val in pairs(s) do
+            if string.sub(key, 1, 1) ~= '.' then
+              data[key] = val
+            end
+          end
+        end
+      end)
+    end
+  return data
+end
+
+function mergeInto(config, section, options)
+  local s = uci:get_first(config, section)
+  if (section) then
+    uci:tset(config, s, options)
+  else
+    uci:section(config, section, nil, options)
+  end
+  uci:save(config)
+end
+

--- a/utils/luci-mod-freifunk-ui/Makefile
+++ b/utils/luci-mod-freifunk-ui/Makefile
@@ -8,7 +8,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-mod-freifunk-ui
-PKG_VERSION:=0.0.3
+PKG_VERSION:=0.0.4
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/adminindex.htm
+++ b/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/adminindex.htm
@@ -1,22 +1,15 @@
 <%+header%>
 <%
 local uci = require "luci.model.uci".cursor()
-local contact = uci:get_all("freifunk", "contact")
+local nickname = uci:get("freifunk", "contact", "nickname") or ""
+local name = uci:get("freifunk", "contact", "name") or ""
+local mail = uci:get("freifunk", "contact", "mail") or ""
 local contacturl = luci.dispatcher.build_url(luci.dispatcher.context.path[1], "freifunk", "contact")
 local hostname = uci:get_first ("system", "system", "hostname")
 local latitude = uci:get_first ("system", "system", "latitude")
 local longitude = uci:get_first ("system", "system", "longitude")
 local location = uci:get_first ("system", "system", "location")
 local basicsurl = luci.dispatcher.build_url(luci.dispatcher.context.path[1], "freifunk", "basics")
-local nickname, name, mail
-if not contact then
-	nickname, name, mail = ""
-else
-	nickname = contact.nickname
-	name = contact.name
-	mail = contact.mail
-end
-
 %>
 
 <h2><%:Freifunk Overview%></h2>

--- a/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/contact.htm
+++ b/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/contact.htm
@@ -9,22 +9,15 @@
 
 <% 
 local uci = require "luci.model.uci".cursor()
-local contact = uci:get_all("freifunk", "contact")
-local nickname, name, mail, phone, location, note
-local lon = uci:get_first("system", "system", "longitude")
-local lat = uci:get_first("system", "system", "latitude")
-
-if not contact then
-	nickname, name, homepage, mail, phone, location, note = ""
-else
-	nickname = contact.nickname or ""
-	name = contact.name or ""
-	homepage = contact.homepage or {}
-	mail = contact.mail or ""
-	phone = contact.phone or ""
-	location = uci:get_first("system", "system", "location") or contact.location
-	note = contact.note or ""
-end
+local nickname = uci:get("freifunk", "contact", "nickname") or ""
+local name = uci:get("freifunk", "contact", "name") or ""
+local homepage = uci:get("freifunk", "contact", "homepage") or {}
+local mail = uci:get("freifunk", "contact", "mail") or ""
+local phone = uci:get("freifunk", "contact", "phone") or ""
+local location = uci:get_first("system", "system", "locaton") or uci:get("freifunk", "contact", "location") or ""
+local note = uci:get("freifunk", "contact", "note") or ""
+local lon = uci:get_first("system", "system", "longitude") or ""
+local lat = uci:get_first("system", "system", "latitude") or ""
 %>
 
 <h2><a id="content" name="content"><%:Contact%></a></h2>

--- a/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/index.htm
+++ b/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/index.htm
@@ -9,11 +9,13 @@ local uci = require "luci.model.uci".cursor()
 local sys = require "luci.sys"
 local tpl = require "luci.template"
 local fs = require "nixio.fs"
-local ff = {}
-local ff = uci:get_all("freifunk")
 local http = require "luci.http"
 local disp = require "luci.dispatcher"
 local ipkg = require "luci.model.ipkg"
+
+local community = uci:get("freifunk", "community", "name") or "Freifunk"
+local DefaultText = uci:get("freifunk", "community", "DefaultText") or ""
+local nickname = uci:get("freifunk", "contact", "nickname") or "No Nickname set"
 
 -- only redirect if assistent is installed and no root password is set
 -- we use isfile because the view is not run as root and we can't use
@@ -40,16 +42,6 @@ end
 <%+header%>
 
 <%
-
-if not ff or not ff.community.name then
-	community = "Freifunk"
-	DefaultText = ""
-	nickname = "No Nickname set"
-else
-	community = ff.community.name
-	DefaultText = ff.community.DefaultText
-	nickname = ff.contact.nickname
-end
 
 local co = "profile_" .. community
 --local community = uci:get_first(co, "community", "name") or "Freifunk"


### PR DESCRIPTION
On the 18.06 branch, wireless and dhcp stopped being set up correctly.  The problem is that uci:get_all() always returns a nil table.

wizard: 
* tools.lua has a new function getMergedConfig() which handles the same functionality as needed in wireless.lua and olsr.lua.
* tools.lua has another new function mergeInto() which saves the config and either updates or creates a new section when needed.  This is taken from olsr.lua because the same code is repeated multiple times.
* wireless.lua now calls getMergedConfg() Additionally, integers have been changed to strings.
* olsr.lua now calls getMergedConfig() and mergeInto()
* generalInfo now calls getMerged() and sets each option indivudally

luci-mod-freifunk-ui
* replace calls to get_all() with individual get()s

