### PR TITLE
luci-mod-freifunk-ui: fix the list of community profiles

### DIFF
--- a/utils/luci-mod-freifunk-ui/luasrc/model/cbi/freifunk/basics.lua
+++ b/utils/luci-mod-freifunk-ui/luasrc/model/cbi/freifunk/basics.lua
@@ -15,8 +15,9 @@ community.rmempty = false
 
 local profile
 for profile in fs.glob(profiles) do
-	local name = uci:get_first(profile, "community", "name") or "?"
-	community:value(string.gsub(profile, "/etc/config/profile_", ""), name)
+	profile = string.gsub(profile, "/etc/config/profile_", "")
+	local name = uci:get_first("profile_" .. profile, "community", "name") or "?"
+	community:value(profile, name)
 end
 
 


### PR DESCRIPTION
The call to uci:get_first() was called with a full pathname instead of a config name.  This has been changed by adding a string.gsub() substitution of the pathname with an empty string.