### PR TITLE
Backport Hedy-1.0.x: wizard and freifunk-ui: fix broken uci:get_all code

### DIFF
--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
@@ -1,6 +1,7 @@
 local uci = require "luci.model.uci".cursor()
 local sys = require "luci.sys"
 local fs = require "nixio.fs"
+local tools = require "luci.tools.freifunk.assistent.tools"
 
 f = SimpleForm("ffwizward", "", "")
 f.submit = "Next"
@@ -83,7 +84,11 @@ function main.write(self, section, value)
   uci:set("freifunk", "contact", "location",location:formvalue(section))
 
   local selectedCommunity = community:formvalue(section) or "Freifunk"
-  uci:tset("freifunk", "community", uci:get_all("profile_"..selectedCommunity, "profile"))
+  local mergeList= {"profile_"..selectedCommunity}
+  local profileData = tools.getMergedConfig(mergeList, "community", "profile")
+  for key, val in pairs(profileData) do
+    uci:set("freifunk", "community", key, val)
+  end
   uci:set("freifunk", "community", "name", selectedCommunity)
 
   local latval

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -89,7 +89,7 @@ end
 function main.write(self, section, value)
   if (sharenet == "2") then
     --share internet was not enabled before, set to false now
-    uci:set("ffwizard", "settings", "sharenet", 0)
+    uci:set("ffwizard", "settings", "sharenet", "0")
     uci:save("ffwizard")
   end
 
@@ -243,8 +243,8 @@ function main.write(self, section, value)
     local dhcpbase = uci:get_all("freifunk", "dhcp") or {}
     util.update(dhcpbase, uci:get_all(community, "dhcp") or {})
     dhcpbase.interface = "dhcp"
-    dhcpbase.force = 1
-    dhcpbase.ignore = 0
+    dhcpbase.force = "1"
+    dhcpbase.ignore = "0"
     uci:section("dhcp", "dhcp", "dhcp", dhcpbase)
     uci:set_list("dhcp", "dhcp", "dhcp_option", "119,olsr")
     uci:set("dhcp", "dhcp", "dhcpv6", "server")
@@ -254,8 +254,8 @@ function main.write(self, section, value)
     -- first host address is used by the router
     -- limit is 2 ^ ( 32 - prefix) - 3
     -- do not assign broadcast address to dhcp clients
-    local start = 2
-    local limit = math.pow(2, 32 - dhcpmeshnet:prefix()) - 3
+    local start = "2"
+    local limit = tostring(math.pow(2, 32 - dhcpmeshnet:prefix()) - 3)
     uci:set("dhcp", "dhcp", "start", start)
     uci:set("dhcp", "dhcp", "limit", limit)
 

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -104,6 +104,7 @@ function main.write(self, section, value)
   end
 
   local statistics_installed = ipkg.installed("luci-app-statistics") == true
+  local mergeList = {"freifunk", community}
   uci:foreach("wireless", "wifi-device",
     function(sec)
       local device = sec[".name"]
@@ -138,25 +139,26 @@ function main.write(self, section, value)
       --WIRELESS CONFIG device
       local hwmode = calchwmode(device)
       local deviceSection = (hwmode:find("a")) and "wifi_device_5" or "wifi_device"
-      local devconfig = uci:get_all("freifunk", deviceSection) or {}
-      util.update(devconfig, uci:get_all(community, deviceSection) or {})
-      devconfig.channel = getchannel(device)
+      local devconfig = tools.getMergedConfig(mergeList, "defaults", deviceSection)
+      local devchannel = getchannel(device)
+      devconfig.channel = tostring(devchannel)
       devconfig.hwmode = hwmode
-      devconfig.doth = calcdoth(devconfig.channel)
+      devconfig.doth = calcdoth(devchannel)
       devconfig.htmode = "HT20"
-      devconfig.chanlist = calcchanlist(devconfig.channel)
+      devconfig.chanlist = calcchanlist(devchannel)
       uci:tset("wireless", device, devconfig)
 
       --WIRELESS CONFIG ad-hoc
-      local pre = calcpre(devconfig.channel)
+      local pre = calcpre(devchannel)
       local ifaceSection = (pre == 2) and "wifi_iface" or "wifi_iface_5"
-      local ifconfig = uci:get_all("freifunk", ifaceSection) or {}
-      local ifnameAdhoc = calcifcfg(device).."-".."adhoc".."-"..pre
-      util.update(ifconfig, uci:get_all(community, ifaceSection) or {})
+      local ifconfig = tools.getMergedConfig(mergeList, "defaults", ifaceSection)
+      local ifnameAdhoc = calcifcfg(device).."-".."adhoc".."-"..tostring(pre)
       ifconfig.device = device
       ifconfig.network = calcnif(device)
       ifconfig.ifname = ifnameAdhoc
       ifconfig.mode = "adhoc"
+      -- don't set the dns entry
+      ifconfig.dns = nil
       ifconfig.ssid = uci:get(community, "ssidscheme", devconfig.channel)
       ifconfig.bssid = uci:get(community, "bssidscheme", devconfig.channel)
       uci:section("wireless", "wifi-iface", nil, ifconfig)
@@ -240,8 +242,7 @@ function main.write(self, section, value)
     uci:set("dhcp", "frei_funk", "ip", dhcpmeshnet:minhost():string())
 
     --DHCP CONFIG bridge for wifi APs
-    local dhcpbase = uci:get_all("freifunk", "dhcp") or {}
-    util.update(dhcpbase, uci:get_all(community, "dhcp") or {})
+    local dhcpbase = tools.getMergedConfig(mergeList, "defaults", "dhcp")
     dhcpbase.interface = "dhcp"
     dhcpbase.force = "1"
     dhcpbase.ignore = "0"

--- a/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/olsr.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/olsr.lua
@@ -22,15 +22,14 @@ end
 
 
 function configureOLSR()
+	local mergeList = {"freifunk", community}
 	-- olsr 4
-	local olsrbase = uci:get_all("freifunk", "olsrd") or {}
-	util.update(olsrbase, uci:get_all(community, "olsrd") or {})
-	uci:tset("olsrd", "olsrd", olsrbase)
+	local olsrbase = tools.getMergedConfig(mergeList, "defaults", "olsrd")
+	tools.mergeInto("olsrd", "olsrd", olsrbase)
 
 	-- olsr 6
-	local olsr6base = uci:get_all("freifunk", "olsrd6") or {}
-	util.update(olsr6base, uci:get_all(community, "olsrd6") or {})
-	uci:tset("olsrd6", "olsrd", olsr6base)
+	local olsr6base = tools.getMergedConfig(mergeList, "defaults", "olsrd6")
+	tools.mergeInto("olsrd6", "olsrd", olsr6base)
 
 	-- set HNA for olsr6
 	local ula_prefix = uci:get("network","globals","ula_prefix")
@@ -45,14 +44,8 @@ function configureOLSR()
 	end
 
   -- olsr 4 interface defaults
-  local olsrifbase = uci:get_all("freifunk", "olsr_interface") or {}
-  util.update(olsrifbase, uci:get_all(community, "olsr_interface") or {})
-  local s = uci:get_first("olsrd", "InterfaceDefaults")
-  if (s) then
-    uci:tset("olsrd", s, olsrifbase)
-  else
-    uci:section("olsrd", "InterfaceDefaults", nil, olsrifbase)
-  end
+  local olsrifbase = tools.getMergedConfig(mergeList, "defaults", "olsr_interface")
+  tools.mergeInto("olsrd", "InterfaceDefaults", olsrifbase)
 
   uci:save("olsrd")
 	uci:save("olsrd6")

--- a/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/tools.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/tools.lua
@@ -103,3 +103,39 @@ end
 function logger(msg)
         sys.exec("logger -t ffwizard -p 5 '"..msg.."'")
 end
+
+--Merge the options of multiple config files into a table.
+--
+--configs: an array of strings, each representing a config file.  
+--  The order is important since  the first config file is read, 
+--  then the following.  Any options in the following config files
+--  overwrite the values of any previous config files. 
+--  e.g. {"freifunk", "profile_berlin"}
+--sectionType: the section type to merge. e.g. "defaults"
+--sectionName: the section to merge. e.g. "olsrd"
+function getMergedConfig(configs, sectionType, sectionName)
+	local data = {}
+	for i, config in ipairs(configs) do
+		uci:foreach(config, sectionType,
+			function(s)
+				if s['.name'] == sectionName then
+					for key, val in pairs(s) do
+						if string.sub(key, 1, 1) ~= '.' then
+							data[key] = val
+						end
+					end
+				end
+			end)
+		end
+	return data
+end
+
+function mergeInto(config, section, options)
+	local s = uci:get_first(config, section)
+	if (section) then
+		uci:tset(config, s, options)
+	else
+		uci:section(config, section, nil, options)
+	end
+	uci:save(config)
+end

--- a/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/adminindex.htm
+++ b/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/adminindex.htm
@@ -1,22 +1,15 @@
 <%+header%>
 <%
 local uci = require "luci.model.uci".cursor()
-local contact = uci:get_all("freifunk", "contact")
+local nickname = uci:get("freifunk", "contact", "nickname") or ""
+local name = uci:get("freifunk", "contact", "name") or ""
+local mail = uci:get("freifunk", "contact", "mail") or ""
 local contacturl = luci.dispatcher.build_url(luci.dispatcher.context.path[1], "freifunk", "contact")
 local hostname = uci:get_first ("system", "system", "hostname")
 local latitude = uci:get_first ("system", "system", "latitude")
 local longitude = uci:get_first ("system", "system", "longitude")
 local location = uci:get_first ("system", "system", "location")
 local basicsurl = luci.dispatcher.build_url(luci.dispatcher.context.path[1], "freifunk", "basics")
-local nickname, name, mail
-if not contact then
-	nickname, name, mail = ""
-else
-	nickname = contact.nickname
-	name = contact.name
-	mail = contact.mail
-end
-
 %>
 
 <h2><%:Freifunk Overview%></h2>

--- a/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/contact.htm
+++ b/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/contact.htm
@@ -9,22 +9,15 @@
 
 <% 
 local uci = require "luci.model.uci".cursor()
-local contact = uci:get_all("freifunk", "contact")
-local nickname, name, mail, phone, location, note
-local lon = uci:get_first("system", "system", "longitude")
-local lat = uci:get_first("system", "system", "latitude")
-
-if not contact then
-	nickname, name, homepage, mail, phone, location, note = ""
-else
-	nickname = contact.nickname or ""
-	name = contact.name or ""
-	homepage = contact.homepage or {}
-	mail = contact.mail or ""
-	phone = contact.phone or ""
-	location = uci:get_first("system", "system", "location") or contact.location
-	note = contact.note or ""
-end
+local nickname = uci:get("freifunk", "contact", "nickname") or ""
+local name = uci:get("freifunk", "contact", "name") or ""
+local homepage = uci:get("freifunk", "contact", "homepage") or {}
+local mail = uci:get("freifunk", "contact", "mail") or ""
+local phone = uci:get("freifunk", "contact", "phone") or ""
+local location = uci:get_first("system", "system", "locaton") or uci:get("freifunk", "contact", "location") or ""
+local note = uci:get("freifunk", "contact", "note") or ""
+local lon = uci:get_first("system", "system", "longitude") or ""
+local lat = uci:get_first("system", "system", "latitude") or ""
 %>
 
 <h2><a id="content" name="content"><%:Contact%></a></h2>

--- a/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/index.htm
+++ b/utils/luci-mod-freifunk-ui/luasrc/view/freifunk/index.htm
@@ -9,11 +9,13 @@ local uci = require "luci.model.uci".cursor()
 local sys = require "luci.sys"
 local tpl = require "luci.template"
 local fs = require "nixio.fs"
-local ff = {}
-local ff = uci:get_all("freifunk")
 local http = require "luci.http"
 local disp = require "luci.dispatcher"
 local ipkg = require "luci.model.ipkg"
+
+local community = uci:get("freifunk", "community", "name") or "Freifunk"
+local DefaultText = uci:get("freifunk", "community", "DefaultText") or ""
+local nickname = uci:get("freifunk", "contact", "nickname") or "No Nickname set"
 
 -- only redirect if assistent is installed and no root password is set
 -- we use isfile because the view is not run as root and we can't use
@@ -40,16 +42,6 @@ end
 <%+header%>
 
 <%
-
-if not ff or not ff.community.name then
-	community = "Freifunk"
-	DefaultText = ""
-	nickname = "No Nickname set"
-else
-	community = ff.community.name
-	DefaultText = ff.community.DefaultText
-	nickname = ff.contact.nickname
-end
 
 local co = "profile_" .. community
 --local community = uci:get_first(co, "community", "name") or "Freifunk"


### PR DESCRIPTION
The call to uci:get_all() is only returning nil tables.  The wizard and
freifunk-ui were effected.

In tools.lua, a new functionl getMergedConfig was created to replace
the functionality of the previous calls to uci:get_all().  Another
function mergeInto was created to update the config files.

In wireless.lua, integers have been converted to strings

In freifunk-ui, calls to uci:get_all() were replaced by single calls to
uci:get()

This addresses issue https://github.com/freifunk-berlin/firmware/issues/617
This also fixes the workaround proposed by commit https://github.com/freifunk-berlin/firmware-packages/commit/b2f265d06fcefd5b9e1b0c11ebcfa462675c972e