### PR TITLE
implement "changing uplink"

### DIFF
--- a/defaults/freifunk-berlin-openvpn-files/Makefile
+++ b/defaults/freifunk-berlin-openvpn-files/Makefile
@@ -3,7 +3,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-openvpn-files
-PKG_VERSION:=0.1.0
+PKG_VERSION:=0.1.1
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-z90_openvpn
+++ b/defaults/freifunk-berlin-openvpn-files/uci-defaults/freifunk-berlin-z90_openvpn
@@ -2,6 +2,10 @@
 
 . /lib/functions/freifunk-berlin-network.sh
 
+# in case we are called to recreate the instance-configuration we preserve 
+# the state of ffuplink and restore it later
+ffuplink_state=$(uci -q get openvpn.ffuplink.enabled)
+
 # set set auth-type required for this uplink-type, e.g. for freifunk-wizard
 uci set ffberlin-uplink.uplink.auth=x509
 uci commit ffberlin-uplink.uplink
@@ -14,7 +18,11 @@ uci -q delete openvpn.sample_client
 # installation / upgrade. So we startover with a clean setup.
 uci -q delete openvpn.ffuplink
 uci set openvpn.ffuplink=openvpn
-uci set openvpn.ffuplink.enabled=0
+if [ -z ${ffuplink_state} ]; then
+  uci set openvpn.ffuplink.enabled=0
+else
+  uci set openvpn.ffuplink.enabled=${ffuplink_state}
+fi
 uci set openvpn.ffuplink.client=1
 uci set openvpn.ffuplink.dev=ffuplink
 uci set openvpn.ffuplink.status="/var/log/openvpn-status-ffuplink.log"

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-notunnel-files
-PKG_VERSION:=0.1.0
+PKG_VERSION:=0.2.0
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-z95_notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-z95_notunnel
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+THIS_UPLINKNAME="notunnel"
+
 . /lib/functions/freifunk-berlin-network.sh 
 . /lib/functions/guard.sh
 
@@ -7,9 +9,15 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-if [ $(uci get ffberlin-uplink.preset.current) != "notunnel" ]; then
-  uci set ffberlin-uplink.preset.previous=$(uci get ffberlin-uplink.preset.current)
-  uci set ffberlin-uplink.preset.current="notunnel"
+current_preset=$(uci get ffberlin-uplink.preset.current)
+if [ ${current_preset} != ${THIS_UPLINKNAME} ]; then
+  # do not track preset when it was 'undefined', aka never configured
+  if [ ${current_preset} != "undefined" ]; then
+    logger -t "ffuplink" "uplink-preset has been changed."
+    uci set ffberlin-uplink.preset.previous=${current_preset}
+    create_ffuplink
+  fi
+  uci set ffberlin-uplink.preset.current=${THIS_UPLINKNAME}
 fi
 # set set auth-type required for this uplink-type, e.g. for freifunk-wizard
 uci set ffberlin-uplink.uplink.auth=none
@@ -17,7 +25,7 @@ uci commit ffberlin-uplink
 
 guard "notunnel"
 
-uci delete network.ffuplink_dev
+uci -q delete network.ffuplink_dev
 uci set network.ffuplink_dev=device
 uci set network.ffuplink_dev.type=veth
 uci set network.ffuplink_dev.name=ffuplink
@@ -34,6 +42,5 @@ uci set network.ffuplink_dev.macaddr=$macaddr
 uci set network.wan.ifname="$(uci get network.wan.ifname) ffuplink_wan"
 uci commit network.ffuplink_dev
 
-create_ffuplink
 uci set network.ffuplink.proto=dhcp
 uci commit network.ffuplink

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-z95_notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/uci-defaults/freifunk-berlin-z95_notunnel
@@ -4,6 +4,7 @@ THIS_UPLINKNAME="notunnel"
 
 . /lib/functions/freifunk-berlin-network.sh 
 . /lib/functions/guard.sh
+. /lib/functions.sh
 
 # always set correct masquerading, regardless of guard
 uci set firewall.zone_ffuplink.masq=1
@@ -37,10 +38,12 @@ for byte in 2 3 4 5 6; do
   macaddr=$macaddr`dd if=/dev/urandom bs=1 count=1 2> /dev/null | hexdump -e '1/1 ":%02x"'`
 done
 uci set network.ffuplink_dev.macaddr=$macaddr
-
-# add ffuplink_dev to br-wan
-uci set network.wan.ifname="$(uci get network.wan.ifname) ffuplink_wan"
 uci commit network.ffuplink_dev
+
+# add ffuplink_dev to br-wan if not there
+ifnames=$(uci get network.wan.ifname)
+list_contains ifnames ffuplink_wan || uci set network.wan.ifname="${ifnames} ffuplink_wan"
+uci commit network.wan
 
 uci set network.ffuplink.proto=dhcp
 uci commit network.ffuplink

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/Makefile
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-tunnelberlin-files
-PKG_VERSION:=0.1.0
+PKG_VERSION:=0.2.0
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-openvpn
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-openvpn
@@ -1,16 +1,23 @@
 #!/bin/sh
 
+. /lib/functions/guard.sh
+
 # always set correct masquerading, regardless of guard
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
 if [ $(uci get ffberlin-uplink.preset.current) != "tunnelberlin_openvpn" ]; then
-  uci set ffberlin-uplink.preset.previous=$(uci get ffberlin-uplink.preset.current)
+  # do not track preset when it was 'undefined', aka never configured
+  if [ $(uci get ffberlin-uplink.preset.current) != 'undefined' ]; then
+    logger -t "ffuplink" "uplink-preset has been changed."
+    uci set ffberlin-uplink.preset.previous=$(uci get ffberlin-uplink.preset.current)
+  fi
   uci set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
+  # call uci-default of package freifunk-berlin-openvpn-files again to recreate initial config
+  /rom/etc/uci-defaults/freifunk-berlin-z90_openvpn
 fi
 uci commit ffberlin-uplink
 
-. /lib/functions/guard.sh
 guard "tunnelberlin_openvpn"
 
 uci set openvpn.ffuplink.proto=udp4

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-openvpn
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-openvpn
@@ -17,7 +17,7 @@ if [ ${current_preset} != ${THIS_UPLINKNAME} ]; then
   fi
   uci set ffberlin-uplink.preset.current=${THIS_UPLINKNAME}
   # call uci-default of package freifunk-berlin-openvpn-files again to recreate initial config
-  /rom/etc/uci-defaults/freifunk-berlin-z90_openvpn
+  sh /rom/etc/uci-defaults/freifunk-berlin-z90_openvpn
 fi
 uci commit ffberlin-uplink
 

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-openvpn
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-openvpn
@@ -1,18 +1,21 @@
 #!/bin/sh
 
+THIS_UPLINKNAME="tunnelberlin_openvpn"
+
 . /lib/functions/guard.sh
 
 # always set correct masquerading, regardless of guard
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-if [ $(uci get ffberlin-uplink.preset.current) != "tunnelberlin_openvpn" ]; then
+current_preset=$(uci get ffberlin-uplink.preset.current)
+if [ ${current_preset} != ${THIS_UPLINKNAME} ]; then
   # do not track preset when it was 'undefined', aka never configured
-  if [ $(uci get ffberlin-uplink.preset.current) != 'undefined' ]; then
+  if [ ${current_preset} != "undefined" ]; then
     logger -t "ffuplink" "uplink-preset has been changed."
-    uci set ffberlin-uplink.preset.previous=$(uci get ffberlin-uplink.preset.current)
+    uci set ffberlin-uplink.preset.previous=${current_preset}
   fi
-  uci set ffberlin-uplink.preset.current="tunnelberlin_openvpn"
+  uci set ffberlin-uplink.preset.current=${THIS_UPLINKNAME}
   # call uci-default of package freifunk-berlin-openvpn-files again to recreate initial config
   /rom/etc/uci-defaults/freifunk-berlin-z90_openvpn
 fi

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/Makefile
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-tunnelberlin-tunneldigger-files
-PKG_VERSION:=0.1.0
+PKG_VERSION:=0.2.0
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-tunneldigger
+++ b/uplinks/freifunk-berlin-uplink-tunnelberlin-tunneldigger-files/uci-defaults/freifunk-berlin-z95_tunnelberlin-tunneldigger
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+THIS_UPLINKNAME="tunnelberlin_tunneldigger"
+
 . /lib/functions/freifunk-berlin-network.sh 
 . /lib/functions/guard.sh
 . /lib/functions/system.sh
@@ -8,9 +10,17 @@
 uci set firewall.zone_ffuplink.masq=1
 uci commit firewall
 
-if [ $(uci get ffberlin-uplink.preset.current) != "tunnelberlin_tunneldigger" ]; then
-  uci set ffberlin-uplink.preset.previous=$(uci get ffberlin-uplink.preset.current)
-  uci set ffberlin-uplink.preset.current="tunnelberlin_tunneldigger"
+current_preset=$(uci get ffberlin-uplink.preset.current)
+if [ ${current_preset} != ${THIS_UPLINKNAME} ]; then
+  if [ ${current_preset} != "undefined" ]; then
+      # when the uplink-preset has changed, recreate remember the preset we are coming from
+      # and prepare for reinit of the relevant settings via freifunk-berlin-ffuplink-defaults
+      # uci-defaults
+      logger -t "ffuplink" "uplink-preset has been changed."
+      uci set ffberlin-uplink.preset.previous=${current_preset}
+      create_ffuplink
+  fi
+  uci set ffberlin-uplink.preset.current=${THIS_UPLINKNAME}
 fi
 # set set auth-type required for this uplink-type, e.g. for freifunk-wizard
 uci set ffberlin-uplink.uplink.auth=none
@@ -30,7 +40,6 @@ done
 uci set network.ffuplink_dev.macaddr=$macaddr
 uci commit network.ffuplink_dev
 
-create_ffuplink
 uci set network.ffuplink.proto=dhcp
 uci commit network.ffuplink
 

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/Makefile
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-vpn03-files
-PKG_VERSION:=0.1.0
+PKG_VERSION:=0.2.0
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-z95_vpn03
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-z95_vpn03
@@ -1,16 +1,27 @@
 #!/bin/sh
 
+THIS_UPLINKNAME="vpn03_openvpn"
+
+. /lib/functions/guard.sh
+
 # always set correct masquerading, regardless of guard
 uci set firewall.zone_ffuplink.masq=0
 uci commit firewall
 
-if [ $(uci get ffberlin-uplink.preset.current) != "vpn03_openvpn" ]; then
-  uci set ffberlin-uplink.preset.previous=$(uci get ffberlin-uplink.preset.current)
-  uci set ffberlin-uplink.preset.current="vpn03_openvpn"
+current_preset=$(uci get ffberlin-uplink.preset.current)
+if [ ${current_preset} != ${THIS_UPLINKNAME} ]; then
+  # do not track preset when it was 'undefined', aka never configured
+  if [ ${current_preset} != "undefined" ]; then
+    logger -t "ffuplink" "uplink-preset has been changed."
+    uci set ffberlin-uplink.preset.previous=${current_preset}
+  fi
+  uci set ffberlin-uplink.preset.current=${THIS_UPLINKNAME}
+  # call uci-default of package freifunk-berlin-openvpn-files again to recreate initial config
+  /rom/etc/uci-defaults/freifunk-berlin-z90_openvpn
 fi
 uci commit ffberlin-uplink
 
-. /lib/functions/guard.sh
+# This sets up this uplinks individual parameters
 guard "vpn03_openvpn"
 
 uci set openvpn.ffuplink.proto=udp4

--- a/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-z95_vpn03
+++ b/uplinks/freifunk-berlin-uplink-vpn03-files/uci-defaults/freifunk-berlin-z95_vpn03
@@ -17,7 +17,7 @@ if [ ${current_preset} != ${THIS_UPLINKNAME} ]; then
   fi
   uci set ffberlin-uplink.preset.current=${THIS_UPLINKNAME}
   # call uci-default of package freifunk-berlin-openvpn-files again to recreate initial config
-  /rom/etc/uci-defaults/freifunk-berlin-z90_openvpn
+  sh /rom/etc/uci-defaults/freifunk-berlin-z90_openvpn
 fi
 uci commit ffberlin-uplink
 


### PR DESCRIPTION
This adds the code, which handles changing the uplink-preset.
It's done by comparing the "ffberlin-uplink.preset.current" with the definition in the currently installed preset. The UCI-value can be:
* the preset used before this image was installed
* value "undefined" when no preset was setup ever, normally a fresh install
When a real preset-change is detected the function "create_ffuplink()" is called to reinit the ffuplink-settings to factory-defaults.