### PR TITLE
luci-app-owm: rm luci-lib-luaneightbl DEPENDS.

### DIFF
--- a/utils/luci-app-owm/Makefile
+++ b/utils/luci-app-owm/Makefile
@@ -27,7 +27,7 @@ endef
 
 define Package/luci-app-owm
   $(call Package/luci-app-owm/default)
-  DEPENDS:=+luci-lib-json +olsrd-mod-jsoninfo +luci-lib-luaneightbl
+  DEPENDS:=+luci-lib-json +olsrd-mod-jsoninfo +luci-mod-network
   TITLE:=Luci JSON Export for Open Wireless Map
 endef
 


### PR DESCRIPTION
all functions are also in luci-lib-ip. it is included by luci-mod-network --> luci-base
see pr https://github.com/openwrt/luci/pull/2507 on luci

Signed-off-by: Patrick Grimm <patrick@lunatiki.de>