### PR TITLE
Add 802.11s support to the wizard

### DIFF
--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -3,8 +3,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ffwizard-berlin
-PKG_VERSION:=0.0.15
-PKG_RELEASE:=2
+PKG_VERSION:=0.0.16
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ffwizard-berlin
 PKG_VERSION:=0.0.15
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -60,6 +60,9 @@ uci:foreach("wireless", "wifi-device",
     local meshmode = f:field(ListValue, "mode_" .. device, "Mesh Mode", "")
     meshmode:value("80211s", "802.11s")
     meshmode:value("adhoc", "Ad-Hoc (veraltet)")
+    function meshmode.cfgvalue(self, section)
+      return uci:get("ffwizard", "settings", "meshmode_" .. device)
+    end
     wifi_tbl[device]["meshmode"] = meshmode
 
   end)
@@ -123,6 +126,9 @@ function main.write(self, section, value)
       -- store wizard data to fill fields if wizard is rerun
       uci:set("ffwizard", "settings",
         "meship_" .. device, wifi_tbl[device]["meship"]:formvalue(section)
+      )
+      uci:set("ffwizard", "settings",
+        "meshmode_" .. device, wifi_tbl[device]["meshmode"]:formvalue(section)
       )
 
       if (string.len(wifi_tbl[device]["meship"]:formvalue(section)) == 0) then


### PR DESCRIPTION
The settings used by the wizard are mostly set in ```/etc/config/freifunk`` and optionally overridden in the community profile.  Commit b0545ac creates the ```'80211s'``` defaults section in ```/etc/config/freifunk```.  Any profiles which would like to override the default (such as the mesh_id) need to make commits to the pofiles in Luci.

The default options are
```
uci set freifunk.80211s=defaults
uci set freifunk.80211s.mode='mesh'
uci set freifunk.80211s.encryption='none'
uci set freifunk.80211s.mesh_id='Mesh-Freifunk'
uci set freifunk.80211s.mesh_fwding='0'

uci set profile_berlin.80211s=defaults
uci set profile_berlin.80211s.mesh_id="Mesh-Freifunk-Berlin"
```

The user can select between the new default 802.11s mode and the legacy adhoc mode.  To make it possible to know the difference between RADIO0 and RADIO1, the radio labels now include it's operating frequency.