### PR TITLE
add pingcheck monitoring for the wan interface

### DIFF
--- a/defaults/freifunk-berlin-network-defaults/Makefile
+++ b/defaults/freifunk-berlin-network-defaults/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-network-defaults
-PKG_VERSION:=0.1.0
+PKG_VERSION:=0.2.0
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
@@ -13,7 +13,7 @@ define Package/freifunk-berlin-network-defaults
   CATEGORY:=freifunk-berlin
   TITLE:=Freifunk Berlin network default configuration
   URL:=http://github.com/freifunk-berlin/packages_berlin
-  DEPENDS+= +freifunk-berlin-lib-guard +iwinfo
+  DEPENDS+= +freifunk-berlin-lib-guard +iwinfo +pingcheck
   PKGARCH:=all
 endef
 
@@ -38,6 +38,10 @@ define Package/freifunk-berlin-network-defaults/install
 	$(CP) ./hotplug.d/iface/* $(1)/etc/hotplug.d/iface/
 	$(INSTALL_DIR) $(1)/lib/functions
 	$(CP) ./lib/functions/* $(1)/lib/functions/
+	$(INSTALL_DIR) $(1)/etc/pingcheck/online.d
+	$(CP) ./pingcheck/online.d/* $(1)/etc/pingcheck/online.d/
+	$(INSTALL_DIR) $(1)/etc/pingcheck/offline.d
+	$(CP) ./pingcheck/offline.d/* $(1)/etc/pingcheck/offline.d/
 endef
 
 $(eval $(call BuildPackage,freifunk-berlin-network-defaults))

--- a/defaults/freifunk-berlin-network-defaults/pingcheck/offline.d/60-freifunk-wan
+++ b/defaults/freifunk-berlin-network-defaults/pingcheck/offline.d/60-freifunk-wan
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+[ "$INTERFACE" = wan ] || exit
+
+# Internet connectivity via WAN is down, reroute all locally generated traffic
+# over the mesh network.
+logger -t freifunk-pingcheck "WAN is down, rerouting all local traffic over the mesh network"
+ip rule add prio 3000 iif lo lookup olsr-tunnel
+ip rule add prio 3001 iif lo lookup olsr-default
+

--- a/defaults/freifunk-berlin-network-defaults/pingcheck/online.d/60-freifunk-wan
+++ b/defaults/freifunk-berlin-network-defaults/pingcheck/online.d/60-freifunk-wan
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+[ "$INTERFACE" = wan ] || exit
+
+# Internet connectivity via WAN is up, reroute all locally generated traffic
+# over WAN.
+logger -t freifunk-pingcheck "WAN connectivity is up, routing all local traffic through WAN"
+ip rule del prio 3000 iif lo lookup olsr-tunnel
+ip rule del prio 3001 iif lo lookup olsr-default
+

--- a/defaults/freifunk-berlin-network-defaults/uci-defaults/freifunk-berlin-pingcheck-defaults
+++ b/defaults/freifunk-berlin-network-defaults/uci-defaults/freifunk-berlin-pingcheck-defaults
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+. /lib/functions.sh
+
+# remove the sta interface, leaving only wan
+uci del pingcheck.@interface\[1\]
+
+# set the host to the anycast host livecheck.berlin.freifunk.net
+uci set pingcheck.@default\[0\].host=livecheck.berlin.freifunk.net
+
+# set the default timeout to 60 seconds
+uci set pingcheck.@default\[0\].timeout=60
+
+uci commit pingcheck
+

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/Makefile
@@ -2,7 +2,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uplink-notunnel-files
-PKG_VERSION:=0.2.0
+PKG_VERSION:=0.3.0
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
@@ -14,7 +14,7 @@ define Package/$(PKG_NAME)
   CATEGORY:=freifunk-berlin
   TITLE:=Freifunk Berlin no tunnel files
   URL:=http://github.com/freifunk-berlin/packages_berlin
-  DEPENDS+=+freifunk-berlin-lib-guard +kmod-veth +freifunk-berlin-network-defaults
+  DEPENDS+=+freifunk-berlin-lib-guard +kmod-veth +freifunk-berlin-network-defaults +pingcheck
   PROVIDES:=freifunk-berlin-uplink
   PKGARCH:=all
 endef
@@ -38,6 +38,10 @@ endef
 define Package/$(PKG_NAME)/install
 	$(INSTALL_DIR) $(1)/etc/uci-defaults
 	$(CP) ./uci-defaults/* $(1)/etc/uci-defaults
+	$(INSTALL_DIR) $(1)/etc/pingcheck/online.d
+	$(CP) ./files/etc/pingcheck/online.d/* $(1)/etc/pingcheck/online.d
+	$(INSTALL_DIR) $(1)/etc/pingcheck/offline.d
+	$(CP) ./files/etc/pingcheck/offline.d/* $(1)/etc/pingcheck/offline.d
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/files/etc/pingcheck/offline.d/60-freifunk-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/files/etc/pingcheck/offline.d/60-freifunk-notunnel
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+[ "$INTERFACE" = wan ] || exit
+
+. /lib/functions.sh
+
+config_load ffberlin-uplink
+config_get ffuplink preset current
+
+[ "$ffuplink" = notunnel ] || exit
+
+# Internet connectivity via WAN is up, start the ffuplink interface
+logger -t freifunk-pingcheck "WAN is down, stopping ffuplink"
+ifdown ffuplink
+

--- a/uplinks/freifunk-berlin-uplink-no-tunnel/files/etc/pingcheck/online.d/60-freifunk-notunnel
+++ b/uplinks/freifunk-berlin-uplink-no-tunnel/files/etc/pingcheck/online.d/60-freifunk-notunnel
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+[ "$INTERFACE" = wan ] || exit
+
+. /lib/functions.sh
+
+config_load ffberlin-uplink
+config_get ffuplink preset current
+
+[ "$ffuplink" = notunnel ] || exit
+
+# Make sure ffuplink is not already up
+. /usr/share/libubox/jshn.sh
+json_load "$(ubus call network.interface.ffuplink status)"
+json_select $1
+json_get_vars up
+[ "$up" == "0" ] || exit
+
+# Internet connectivity via WAN is up, start the ffuplink interface
+# In the case where ffuplink is set disabled '1', then ifup dies quietly
+logger -t freifunk-pingcheck "WAN is up, starting ffuplink"
+ifup ffuplink


### PR DESCRIPTION
When the wan interface looses internet connectivity, The no-tunnel uplink does not go down automatically.  Additionally, and locally generated traffic will still continue to use the wan interface (dnsmasq, statistics, ping).

uplink no-tunnel:
The scripts, when installed with pingcheck, will take down or up the ffuplink interface when the internet is not reachable via the wan interface.
    
The pingcheck package is now a dependency of freifunk-berlin-uplink-no-tunnel

network-defaults:
The scripts, when installed with pingcheck, will set routing rules for locally generated traffic depending on if the wan interface has connectivity to the internet.  When the wan interface looses connectivity, new ip rules are put in place to put the olsr-tunnel and olsr-default tables with a higher priority than the main table. When connectivity returns, the rules are removed.

The pingcheck package is now a dependency of freifunk-berlin-network-defaults

Additionally there is the migration.

This addresses issues https://github.com/freifunk-berlin/firmware/issues/659, https://github.com/freifunk-berlin/firmware/issues/660, https://github.com/freifunk-berlin/firmware/issues/623#issuecomment-439982378, 