### PR TITLE
uhttpd defaults: set max_requests to 3

### DIFF
--- a/defaults/freifunk-berlin-uhttpd-defaults/Makefile
+++ b/defaults/freifunk-berlin-uhttpd-defaults/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uhttpd-defaults
-PKG_VERSION:=0.0.1
+PKG_VERSION:=0.0.2
 PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/defaults/freifunk-berlin-uhttpd-defaults/uci-defaults/freifunk-berlin-uhttpd-defaults
+++ b/defaults/freifunk-berlin-uhttpd-defaults/uci-defaults/freifunk-berlin-uhttpd-defaults
@@ -9,4 +9,7 @@ guard "uhttpd"
 uci set uhttpd.px5g.commonname="Freifunk Berlin - $(dd if=/dev/urandom bs=4 count=1 | hexdump -e '1/1 "%02x"')"
 # do not force redirect to https
 uci set uhttpd.main.redirect_https=0
+# allow multiple concurrent requests caused by upstream commit
+# https://github.com/openwrt/openwrt/commit/c6aa9ff38870a30dbe6da17e4edad6039fe10ddf
+uci set uhttpd.main.max_requests=3
 uci commit


### PR DESCRIPTION
Upstream, there has been a change to the default setting of uhttpd.  The
new default does not allow concurrent cgi scripts to run.  The result of this change can
be seen in issue https://github.com/freifunk-berlin/firmware/issues/665

By setting max_requests to 3 (the previous value), the hasRootPass function no longer times out and the wizard runs as expected.

The upstream commit on openwrt/master is
https://github.com/openwrt/openwrt/commit/c6aa9ff38870a30dbe6da17e4edad6039fe10ddf
The upstream commit on openwrt/18.06 is
https://github.com/openwrt/openwrt/commit/e5a0b6cde051bd24280e9c3a360e65617bce2416

This has been compiled locally and tested.