### PR TITLE
ffwizard: remove direct dependency to luci-base

### DIFF
--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ffwizard-berlin
 PKG_VERSION:=0.0.14
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -16,7 +16,7 @@ define Package/luci-app-ffwizard-berlin
   SUBMENU:=3. Applications
   TITLE:=Freifunk Berlin configuration wizard
   URL:=http://berlin.freifunk.net
-  DEPENDS+= +luci-base +luci-mod-admin-full +freifunk-policyrouting
+  DEPENDS+= +luci-mod-admin-full +freifunk-policyrouting
   PKGARCH:=all
 endef
 


### PR DESCRIPTION
as luci-mod-admin-full depends on luci-base (https://github.com/openwrt/luci/blob/openwrt-18.06/modules/luci-mod-admin-full/Makefile#L10) we can drop this dependency.