### PR TITLE
reuse LUCI build-support

### DIFF
--- a/addons/freifunk-berlin-lib-guard/Makefile
+++ b/addons/freifunk-berlin-lib-guard/Makefile
@@ -1,12 +1,9 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-lib-guard
-PKG_VERSION:=0.0.4
 PKG_RELEASE:=1
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
-
-include $(INCLUDE_DIR)/package.mk
+include ../../freifunk-berlin-generic.mk
 
 define Package/freifunk-berlin-lib-guard
   SECTION:=freifunk-berlin

--- a/defaults/freifunk-berlin-dhcp-defaults/Makefile
+++ b/defaults/freifunk-berlin-dhcp-defaults/Makefile
@@ -1,12 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-dhcp-defaults
-PKG_VERSION:=0.0.3
-PKG_RELEASE:=1
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
-
-include $(INCLUDE_DIR)/package.mk
+include ../../freifunk-berlin-generic.mk
 
 define Package/freifunk-berlin-dhcp-defaults
   SECTION:=freifunk-berlin

--- a/defaults/freifunk-berlin-firewall-defaults/Makefile
+++ b/defaults/freifunk-berlin-firewall-defaults/Makefile
@@ -1,12 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-firewall-defaults
-PKG_VERSION:=0.0.6
-PKG_RELEASE:=1
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
-
-include $(INCLUDE_DIR)/package.mk
+include ../../freifunk-berlin-generic.mk
 
 define Package/freifunk-berlin-firewall-defaults
   SECTION:=freifunk-berlin

--- a/defaults/freifunk-berlin-freifunk-defaults/Makefile
+++ b/defaults/freifunk-berlin-freifunk-defaults/Makefile
@@ -1,12 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-freifunk-defaults
-PKG_VERSION:=0.0.2
-PKG_RELEASE:=3
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
-
-include $(INCLUDE_DIR)/package.mk
+include ../../freifunk-berlin-generic.mk
 
 define Package/freifunk-berlin-freifunk-defaults
   SECTION:=freifunk-berlin

--- a/defaults/freifunk-berlin-network-defaults/Makefile
+++ b/defaults/freifunk-berlin-network-defaults/Makefile
@@ -1,12 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-network-defaults
-PKG_VERSION:=0.2.0
-PKG_RELEASE:=1
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
-
-include $(INCLUDE_DIR)/package.mk
+include ../../freifunk-berlin-generic.mk
 
 define Package/freifunk-berlin-network-defaults
   SECTION:=freifunk-berlin

--- a/defaults/freifunk-berlin-olsrd-defaults/Makefile
+++ b/defaults/freifunk-berlin-olsrd-defaults/Makefile
@@ -1,12 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-olsrd-defaults
-PKG_VERSION:=0.0.6
-PKG_RELEASE:=2
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
-
-include $(INCLUDE_DIR)/package.mk
+include ../../freifunk-berlin-generic.mk
 
 define Package/freifunk-berlin-olsrd-defaults
   SECTION:=freifunk-berlin

--- a/defaults/freifunk-berlin-openvpn-files/Makefile
+++ b/defaults/freifunk-berlin-openvpn-files/Makefile
@@ -3,12 +3,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-openvpn-files
-PKG_VERSION:=0.1.1
-PKG_RELEASE:=1
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
-
-include $(INCLUDE_DIR)/package.mk
+include ../../freifunk-berlin-generic.mk
 
 define Package/freifunk-berlin-openvpn-files
   SECTION:=freifunk-berlin

--- a/defaults/freifunk-berlin-statistics-defaults/Makefile
+++ b/defaults/freifunk-berlin-statistics-defaults/Makefile
@@ -1,12 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-statistics-defaults
-PKG_VERSION:=0.0.2
-PKG_RELEASE:=1
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
-
-include $(INCLUDE_DIR)/package.mk
+include ../../freifunk-berlin-generic.mk
 
 define Package/freifunk-berlin-statistics-defaults
   SECTION:=freifunk-berlin

--- a/defaults/freifunk-berlin-system-defaults/Makefile
+++ b/defaults/freifunk-berlin-system-defaults/Makefile
@@ -1,12 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-system-defaults
-PKG_VERSION:=0.0.2
-PKG_RELEASE:=1
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
-
-include $(INCLUDE_DIR)/package.mk
+include ../../freifunk-berlin-generic.mk
 
 define Package/freifunk-berlin-system-defaults
   SECTION:=freifunk-berlin

--- a/defaults/freifunk-berlin-uhttpd-defaults/Makefile
+++ b/defaults/freifunk-berlin-uhttpd-defaults/Makefile
@@ -1,12 +1,8 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-uhttpd-defaults
-PKG_VERSION:=0.0.1
-PKG_RELEASE:=2
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
-
-include $(INCLUDE_DIR)/package.mk
+include ../../freifunk-berlin-generic.mk
 
 define Package/freifunk-berlin-uhttpd-defaults
   SECTION:=freifunk-berlin

--- a/freifunk-berlin-generic.mk
+++ b/freifunk-berlin-generic.mk
@@ -15,4 +15,21 @@ else
 #$(info found luci.mk at $(LUCIMKFILE))
 endif
 
+PKG_VERSION?=$(if $(DUMP),x,$(strip $(shell \
+	if svn info >/dev/null 2>/dev/null; then \
+		revision="svn-r$$(LC_ALL=C svn info | sed -ne 's/^Revision: //p')"; \
+	elif git log -1 >/dev/null 2>/dev/null; then \
+		revision="svn-r$$(LC_ALL=C git log -1 | sed -ne 's/.*git-svn-id: .*@\([0-9]\+\) .*/\1/p')"; \
+		if [ "$$revision" = "svn-r" ]; then \
+			set -- $$(git log -1 --format="%ct %h" --abbrev=7); \
+			secs="$$(($$1 % 86400))"; \
+			yday="$$(date --utc --date="@$$1" "+%y.%j")"; \
+			revision="$$(printf 'git-%s.%05d-%s' "$$yday" "$$secs" "$$2")"; \
+		fi; \
+	else \
+		revision="unknown"; \
+	fi; \
+	echo "$$revision" \
+)))
+
 include $(LUCIMKFILE)

--- a/freifunk-berlin-generic.mk
+++ b/freifunk-berlin-generic.mk
@@ -21,7 +21,7 @@ PKG_VERSION?=$(if $(DUMP),x,$(strip $(shell \
 	elif git log -1 >/dev/null 2>/dev/null; then \
 		revision="svn-r$$(LC_ALL=C git log -1 | sed -ne 's/.*git-svn-id: .*@\([0-9]\+\) .*/\1/p')"; \
 		if [ "$$revision" = "svn-r" ]; then \
-			set -- $$(git log -1 --format="%ct %h" --abbrev=7); \
+			set -- $$(git log -1 --format="%ct %h" --abbrev=7 .); \
 			secs="$$(($$1 % 86400))"; \
 			yday="$$(date --utc --date="@$$1" "+%y.%j")"; \
 			revision="$$(printf 'git-%s.%05d-%s' "$$yday" "$$secs" "$$2")"; \

--- a/freifunk-berlin-generic.mk
+++ b/freifunk-berlin-generic.mk
@@ -1,0 +1,18 @@
+#
+# This is free software, licensed under the GNU General Public License v3.0 .
+#
+
+LUCIMKFILE:=$(wildcard $(TOPDIR)/feeds/*/luci.mk)
+
+# verify that there is only one single file returned
+ifneq (1,$(words $(LUCIMKFILE)))
+ifeq (0,$(words $(LUCIMKFILE)))
+$(error did not find luci.mk in any feed)
+else
+$(error found multiple luci.mk files in the feeds)
+endif
+else
+#$(info found luci.mk at $(LUCIMKFILE))
+endif
+
+include $(LUCIMKFILE)

--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -2,55 +2,12 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=luci-app-ffwizard-berlin
-PKG_VERSION:=0.0.16
-PKG_RELEASE:=3
+LUCI_TITLE:=Freifunk Berlin configuration wizard
+LUCI_DEPENDS:=+luci-mod-admin-full +freifunk-policyrouting +luci-lib-jsonc +community-profiles +luci-lib-ipkg
+PKG_RELEASE:=4
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+include ../../freifunk-berlin-generic.mk
 
-include $(INCLUDE_DIR)/package.mk
+#  URL:=http://berlin.freifunk.net
 
-define Package/luci-app-ffwizard-berlin
-  SECTION:=luci
-  CATEGORY:=LuCI
-  SUBMENU:=3. Applications
-  TITLE:=Freifunk Berlin configuration wizard
-  URL:=http://berlin.freifunk.net
-  DEPENDS+= +luci-mod-admin-full +freifunk-policyrouting +luci-lib-jsonc +community-profiles +luci-lib-ipkg
-  PKGARCH:=all
-endef
-
-define Package/luci-app-ffwizard-berlin/description
-  Freifunk Wizard for Berlin
-endef
-
-define Build/Prepare
-	mkdir -p $(PKG_BUILD_DIR)
-	$(CP) ./luasrc $(PKG_BUILD_DIR)/
-endef
-
-define Build/Configure
-endef
-
-define Build/Compile
-	$(MAKE) -C $(PKG_BUILD_DIR)/luasrc
-endef
-
-define Package/luci-app-ffwizard-berlin/install
-	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/controller
-	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/model
-	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/tools
-	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/view
-	$(CP) $(PKG_BUILD_DIR)/luasrc/controller/* $(1)/usr/lib/lua/luci/controller
-	$(CP) $(PKG_BUILD_DIR)/luasrc/model/* $(1)/usr/lib/lua/luci/model
-	$(CP) $(PKG_BUILD_DIR)/luasrc/tools/* $(1)/usr/lib/lua/luci/tools
-	$(CP) $(PKG_BUILD_DIR)/luasrc/view/* $(1)/usr/lib/lua/luci/view
-	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d/
-	$(CP) ./root/usr/share/rpcd/acl.d/ffwizard-berlin.json $(1)/usr/share/rpcd/acl.d/ffwizard-berlin.json
-	$(INSTALL_DIR) $(1)/etc
-	$(CP) ./root/etc/* $(1)/etc
-	$(INSTALL_DIR) $(1)/usr/libexec/rpcd
-	$(CP) ./root/usr/libexec/rpcd/* $(1)/usr/libexec/rpcd/
-endef
-
-$(eval $(call BuildPackage,luci-app-ffwizard-berlin))
+# call BuildPackage - OpenWrt buildroot signature

--- a/utils/luci-mod-freifunk-ui/Makefile
+++ b/utils/luci-mod-freifunk-ui/Makefile
@@ -7,44 +7,11 @@
 
 include $(TOPDIR)/rules.mk
 
-PKG_NAME:=luci-mod-freifunk-ui
-PKG_VERSION:=0.0.4
-PKG_RELEASE:=2
+LUCI_TITLE:=Freifunk Public and Admin LuCI UI
+LUCI_DEPENDS:=+luci-mod-admin-full +luci-lib-json +community-profiles +luci-lib-ipkg
+LUCI_PKGARCH:=all
+PKG_RELEASE:=3
 
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
+include ../../freifunk-berlin-generic.mk
 
-include $(INCLUDE_DIR)/package.mk
-
-define Package/luci-mod-freifunk-ui
-  SECTION:=luci
-  CATEGORY:=LuCI
-  SUBMENU:=2. Modules
-  TITLE:=Freifunk Public and Admin LuCI UI
-  DEPENDS:=+luci-mod-admin-full +luci-lib-json +community-profiles +luci-lib-ipkg
-  PKGARCH:=all
-endef
-
-define Build/Prepare
-	mkdir -p $(PKG_BUILD_DIR)
-	$(CP) ./luasrc $(PKG_BUILD_DIR)/
-endef
-
-define Build/Configure
-endef
-
-define Build/Compile
-#	$(MAKE) -C $(PKG_BUILD_DIR)/luasrc
-endef
-
-define Package/luci-mod-freifunk-ui/install
-	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/controller
-	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/model
-	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/view
-	$(CP) $(PKG_BUILD_DIR)/luasrc/controller/* $(1)/usr/lib/lua/luci/controller
-	$(CP) $(PKG_BUILD_DIR)/luasrc/model/* $(1)/usr/lib/lua/luci/model
-	$(CP) $(PKG_BUILD_DIR)/luasrc/view/* $(1)/usr/lib/lua/luci/view
-	$(INSTALL_DIR) $(1)/www
-	$(CP) ./htdocs/* $(1)/www
-endef
-
-$(eval $(call BuildPackage,luci-mod-freifunk-ui))
+# call BuildPackage - OpenWrt buildroot signature


### PR DESCRIPTION
This PR implements the use of "luci.mk" from the LUCI feed to reuse its macros and definitions. So the packages-makefiles can be kept a bit more simple and use features like SRCDIET and automatic build of translations.
Some of our packages will be changed to use versionnumbering based on the githash, which removes the need for taking care of this "detail".

This also fixes https://github.com/freifunk-berlin/firmware/issues/584