### PR TITLE
migration: remove cleaning non-profile config files from jffs system

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/zz_freifunk-berlin-migration-clean_jffs.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/zz_freifunk-berlin-migration-clean_jffs.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
 
-# delete any overlay config files duplicated from romfs by sysupgrade - saves JFFS2 space
-cd /overlay/upper/etc/config/ && for i in *; do [ -f "$i" ] && if cmp -s "$i" "/rom/etc/config/$i"; then rm -f "$i"; fi; done;
+# delete any overlay profile config files duplicated from romfs by 
+# sysupgrade - saves JFFS2 space
+cd /overlay/upper/etc/config/ && for i in profile_*; do [ -f "$i" ] && if cmp -s "$i" "/rom/etc/config/$i"; then rm -f "$i"; fi; done;


### PR DESCRIPTION
The removal of non-profile config files breaks the ability to configure any remaining and as yet untouched configurations.  The result of trying to modify one of the config files removed in the /overlay filesystem results in ```uci: I/O error```

This has been documented in https://github.com/freifunk-berlin/firmware/issues/641