### PR TITLE
disable ffuplink-interface during initial setup - revisited

### DIFF
--- a/defaults/freifunk-berlin-network-defaults/Makefile
+++ b/defaults/freifunk-berlin-network-defaults/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-network-defaults
-PKG_VERSION:=0.1.0
+PKG_VERSION:=0.1.1
 PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)

--- a/defaults/freifunk-berlin-network-defaults/uci-defaults/freifunk-berlin-ffuplink-defaults
+++ b/defaults/freifunk-berlin-network-defaults/uci-defaults/freifunk-berlin-ffuplink-defaults
@@ -15,3 +15,5 @@ uci set ffberlin-uplink.uplink.auth=none
 uci commit ffberlin-uplink
 
 create_ffuplink
+uci set network.ffuplink.disabled=1
+uci commit network.ffuplink

--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -4,7 +4,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=luci-app-ffwizard-berlin
 PKG_VERSION:=0.0.15
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -88,6 +88,11 @@ function main.write(self, section, value)
     --share internet was not enabled before, set to false now
     uci:set("ffwizard", "settings", "sharenet", "0")
     uci:save("ffwizard")
+    --in case the wizard has been re-ran, ensure ffuplink is disabled
+    uci:set("network", "ffuplink", "disabled", "1")
+  else
+    --sharenet was enabled, therefore enable the ffuplink network interface
+    uci:set("network", "ffuplink", "disabled", "0")
   end
 
   -- store wizard data to fill fields if wizard is rerun


### PR DESCRIPTION
This is an alternative to PR #185 

In this version, the option network.ffuplink.disabled is set to 0 in the wizard if sharenet is selected.  Additionally, if sharenet is disabled (for example re-running the wizard), the same option is set to 1.

Quoted from https://github.com/freifunk-berlin/firmware-packages/pull/185#issue-261869574
> On a fresh installed system, there is no valid setup of ffuplink. So we disable this interface, till it's configured by some uplink-preset.
> The advantage of this change s, that an unconfigured ffuplink (as so uplink-preset was installed for manual configuration) will not cause any unintended sideeffects.

This implementation has been tested and passes the tests described in https://github.com/freifunk-berlin/firmware-packages/pull/185#issuecomment-474150669
