### PR TITLE
defaults and migration: update to new digitalcourage nameservers

### DIFF
--- a/defaults/freifunk-berlin-olsrd-defaults/Makefile
+++ b/defaults/freifunk-berlin-olsrd-defaults/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-olsrd-defaults
 PKG_VERSION:=0.0.6
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/defaults/freifunk-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
+++ b/defaults/freifunk-berlin-olsrd-defaults/uci-defaults/freifunk-berlin-olsrd-defaults
@@ -40,7 +40,7 @@ uci set olsrd.$PLUGIN.interval=30
 # add dyngw plain plugin - it is ipv4 only
 PLUGIN="$(uci add olsrd LoadPlugin)"
 uci set olsrd.$PLUGIN.library=olsrd_dyn_gw
-uci add_list olsrd.$PLUGIN.Ping=85.214.20.141     # dns.digitalcourage.de
+uci add_list olsrd.$PLUGIN.Ping=46.182.19.48      # dns.digitalcourage.de
 uci add_list olsrd.$PLUGIN.Ping=80.67.169.40      # www.fdn.fr/actions/dns
 uci add_list olsrd.$PLUGIN.Ping=194.150.168.168   # dns.as250.net
 uci set olsrd.$PLUGIN.ignore=0

--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
 PKG_VERSION:=0.6.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -432,6 +432,8 @@ r1_1_0_olsrd_dygw_ping() {
     if[ -z "${lib##olsrd_dyn_gw.so*}" ]; then
       uci del_list olsrd.$config.Ping=213.73.91.35   # dnscache.ccc.berlin.de
       uci add_list olsrd.$config.Ping=80.67.169.40   # www.fdn.fr/actions/dns
+      uci del_list olsrd.$config.Ping=85.214.20.141  # old digitalcourage
+      uci add_list olsrd.$config.Ping=46.182.19.48   # new digitalcourage
       return 1
     fi
   }


### PR DESCRIPTION
olsrd defaults: update to use the new digitalcourage nameservers
migration: update to new digitalcourage nameservers

The old digitalcourage nameserver 85.214.20.141 will be retired in 2020. The new nameserver id 46.182.19.48.  This commit updates the list of nodes to ping in the OLSRd defaults.

The change is announced https://digitalcourage.de/support/zensurfreier-dns-server

This fixes https://github.com/freifunk-berlin/firmware/issues/682