### PR TITLE
migration: update to the most recent profiles and freifunk defaults

### DIFF
--- a/utils/freifunk-berlin-migration/Makefile
+++ b/utils/freifunk-berlin-migration/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-migration
 PKG_VERSION:=0.6.2
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 

--- a/utils/freifunk-berlin-migration/uci-defaults/zz_freifunk-berlin-migration-clean_jffs.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/zz_freifunk-berlin-migration-clean_jffs.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-
-# delete any overlay config files duplicated from romfs by sysupgrade - saves JFFS2 space
-cd /overlay/upper/etc/config/ && for i in *; do [ -f "$i" ] && if cmp -s "$i" "/rom/etc/config/$i"; then rm -f "$i"; fi; done;


### PR DESCRIPTION
Upon upgrade, the files /etc/config/profile_* and /etc/config/freifunk
are not automatically upgraded to the newest version.  This commit
pulls the profile_* out of the rom partition and overwrites the
profiles in /etc/config.

Additionally the freifunk config is handeled seperately.  This config
file is a mixure of defaults with the addition of the 'contact' and
'community' sections which are configured for the running system.
In this case, the version from rom is copied into /etc/config and
the 'contact' and 'community' sections from the old setup
are imported.

This fixes https://github.com/freifunk-berlin/firmware/issues/641
This also adresses https://github.com/freifunk-berlin/firmware-packages/pull/189#issuecomment-502814486
and https://github.com/freifunk-berlin/firmware-packages/pull/189#issuecomment-502855417