### PR TITLE
dhcp-defaults: enable DHCP-rapid commit by default

### DIFF
--- a/defaults/freifunk-berlin-dhcp-defaults/uci-defaults/freifunk-berlin-dhcp-defaults
+++ b/defaults/freifunk-berlin-dhcp-defaults/uci-defaults/freifunk-berlin-dhcp-defaults
@@ -5,6 +5,8 @@ guard "dhcp"
 
 # quieten down dnsmasq a bit (do not log lease-mgmt)
 uci set dhcp.@dnsmasq[0].quietdhcp=1
+# enable DHCP-rapidcommit (RFC4039)
+uci set dhcp.@dnsmasq[0].rapidcommit=1
 
 # on IPv6-islands we also should give a default-route to the clients,
 # so they can also reach IPv6-neighbours. 


### PR DESCRIPTION
As per RFC4039:
   In some environments, such as those in which high mobility occurs and
   the network attachment point changes frequently, it is beneficial to
   rapidly configure clients.  And, in these environments it is possible
   to more quickly configure clients because the protections offered by
   the normal (and longer) 4-message exchange may not be needed.  The
   4-message exchange allows for redundancy (multiple DHCP servers)
   without wasting addresses, as addresses are only provisionally
   assigned to a client until the client chooses and requests one of the
   provisionally assigned addresses.  The 2-message exchange may
   therefore be used when only one server is present or when addresses
   are plentiful and having multiple servers commit addresses for a
   client is not a problem.

The DHCP-v4 extension is based on the DHCP-v6 variant of RFC3315.

This addresses https://github.com/freifunk-berlin/firmware/issues/664