### PR TITLE
collectd-addons/snmp: scale uptime to days

### DIFF
--- a/addons/collectd-addons/files/collectd-snmp/ubnt-airmax.conf
+++ b/addons/collectd-addons/files/collectd-snmp/ubnt-airmax.conf
@@ -5,7 +5,8 @@ LoadPlugin snmp
     <Data "ifmib_uptime">
 	Type "uptime"
 	Table false
-	Instance "system"
+	Instance "days"
+	Scale 1.15740740741e-07
 	Values "DISMAN-EVENT-MIB::sysUpTimeInstance"
     </Data>
     <Data "rf_signalstrength">


### PR DESCRIPTION
* sysUpTimeInstance is measured in 100/second
* scale it down to more meaningful days of uptime (as it's done for collectd-uptime by default)