### PR TITLE
define an internal "Non release flag" 

### DIFF
--- a/defaults/freifunk-berlin-system-defaults/uci-defaults/freifunk-berlin-system-defaults
+++ b/defaults/freifunk-berlin-system-defaults/uci-defaults/freifunk-berlin-system-defaults
@@ -1,12 +1,22 @@
 #!/bin/sh
 
 . /lib/functions/guard.sh
+. /etc/openwrt_release
 
 # change default hostname
 if [ $(uci get system.@system[0].hostname) = OpenWrt ]; then
   uci set system.@system[0].hostname=gib-mir-einen-namen
   uci commit system
 fi
+
+# set system.was_development flag if running non-releasecode was detected
+SEMVER=$(echo ${DISTRIB_RELEASE%%-*} | \
+  grep -E "^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$")
+if [ -z ${SEMVER} ] && [ "$(uci -q get system.@system[0].was_development)" != "1" ]; then
+  uci set system.@system[0].was_development=1
+  uci commit system
+fi
+
 
 guard "system"
 

--- a/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/freifunk-berlin-01-migration.sh
@@ -5,6 +5,11 @@ source /lib/functions/semver.sh
 source /etc/openwrt_release
 source /lib/functions/guard.sh
 
+if [ $( uci -q get system.@system[0].was_development) = "1" ]; then
+  echo "Non released code was ran on system. skipping migration ..."
+  exit 0
+fi
+
 # possible cases: 
 # 1) firstboot with kathleen --> uci system.version not defined
 # 2) upgrade from kathleen --> uci system.version defined


### PR DESCRIPTION
Define a uci "system.was_development" flag, which signals, that the node has ran development code once. This flag might be useful to signal that the system might have conflicting settings, due to an specific development-branch. 
A development-branch might define a setting, which is different in the final release, but can potentially cause malfunction. As of our long release-pauses also regular users have to use development-firmware, to support their hardware (a.t.m. >100 such nodes online). 
Very likely many of these users run such firmware, as it's their only option. When a release will be ready, these people very likely just upgrade to this release. I don't know if there is a specific version around where this will cause problems, now or even in a further release.

As a simple example I made a check into the migration-script to not run automatically on such nodes. The migration can be started manually and checked for running correct.
