### PR TITLE
add new package "freifunk-berlin-lua-tools"

### DIFF
--- a/addons/freifunk-berlin-lua-tools/Makefile
+++ b/addons/freifunk-berlin-lua-tools/Makefile
@@ -1,0 +1,16 @@
+
+include $(TOPDIR)/rules.mk
+
+PKG_RELEASE:=1
+
+LUCI_TITLE:=Freifunk Berlin lua tools
+LUCI_DESCRIPTION:=common helper tools used by Freifunk-Berlin packages
+LUCI_DEPENDS:=luci-lib-base
+
+define Package/freifunk-berlin-lua-tools/postinst
+# noop
+endef
+
+include ../../freifunk-berlin-generic.mk
+
+# call BuildPackage - OpenWrt buildroot signature

--- a/addons/freifunk-berlin-lua-tools/luasrc/tools/freifunk/freifunk-berlin.lua
+++ b/addons/freifunk-berlin-lua-tools/luasrc/tools/freifunk/freifunk-berlin.lua
@@ -1,0 +1,65 @@
+local sys = require "luci.sys"
+local util = require "luci.util"
+local uci = require "luci.model.uci".cursor()
+
+module("luci.tools.freifunk.freifunk-berlin", package.seeall)
+
+-- Helpers --
+-- Removes a listentry, handles real and pseduo lists transparently
+function remove_list_entry(value, entry)
+	if type(value) == "nil" then
+		return nil
+	end
+
+	local result = type(value) == "table" and value or util.split(value, " ")
+	local key = util.contains(result, entry)
+
+	while key do
+		table.remove(result, key)
+		key = util.contains(result, entry)
+	end
+
+	result = type(value) == "table" and result or table.concat(result, " ")
+	return result ~= value and result
+end
+
+
+function logger(msg, type, prio)
+	sys.exec("logger -t "..type.." -p "..prio.." '"..msg.."'")
+end
+
+--Merge the options of multiple config files into a table.
+--
+--configs: an array of strings, each representing a config file.  
+--  The order is important since  the first config file is read, 
+--  then the following.  Any options in the following config files
+--  overwrite the values of any previous config files. 
+--  e.g. {"freifunk", "profile_berlin"}
+--sectionType: the section type to merge. e.g. "defaults"
+--sectionName: the section to merge. e.g. "olsrd"
+function getMergedConfig(configs, sectionType, sectionName)
+	local data = {}
+	for i, config in ipairs(configs) do
+		uci:foreach(config, sectionType,
+			function(s)
+				if s['.name'] == sectionName then
+					for key, val in pairs(s) do
+						if string.sub(key, 1, 1) ~= '.' then
+							data[key] = val
+						end
+					end
+				end
+			end)
+		end
+	return data
+end
+
+function mergeInto(config, section, options)
+	local s = uci:get_first(config, section)
+	if (section) then
+		uci:tset(config, s, options)
+	else
+		uci:section(config, section, nil, options)
+	end
+	uci:save(config)
+end

--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -3,8 +3,8 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Freifunk Berlin configuration wizard
-LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +freifunk-policyrouting +luci-lib-jsonc +community-profiles +luci-lib-ipkg
-PKG_RELEASE:=6
+LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +freifunk-policyrouting +luci-lib-jsonc +community-profiles +luci-lib-ipkg +freifunk-berlin-lua-tools
+PKG_RELEASE:=7
 
 include ../../freifunk-berlin-generic.mk
 

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/generalInfo.lua
@@ -1,7 +1,7 @@
 local uci = require "luci.model.uci".cursor()
 local sys = require "luci.sys"
 local fs = require "nixio.fs"
-local tools = require "luci.tools.freifunk.assistent.tools"
+local tools = require "luci.tools.freifunk.freifunk-berlin"
 
 f = SimpleForm("ffwizward", "", "")
 f.submit = "Next"

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -1,7 +1,8 @@
 local uci = require "luci.model.uci".cursor()
 local ip = require "luci.ip"
 local util = require "luci.util"
-local tools = require "luci.tools.freifunk.assistent.tools"
+local tools = require "luci.tools.freifunk.freifunk-berlin"
+local assistenttools = require "luci.tools.freifunk.assistent.tools"
 local ipkg = require "luci.model.ipkg"
 
 local olsr = require "luci.tools.freifunk.assistent.olsr"
@@ -151,7 +152,7 @@ function main.write(self, section, value)
       uci:section("olsrd6", "Interface", nil, olsrifbase6)
 
       --FIREWALL CONFIG device
-      tools.firewall_zone_add_interface("freifunk", calcnif(device))
+      assistenttools.firewall_zone_add_interface("freifunk", calcnif(device))
 
       --WIRELESS CONFIG device
       local hwmode = calchwmode(device)
@@ -185,8 +186,8 @@ function main.write(self, section, value)
       end
       uci:section("wireless", "wifi-iface", nil, ifconfig)
       if statistics_installed then
-        tools.statistics_interface_add("collectd_iwinfo", ifnameMesh)
-        tools.statistics_interface_add("collectd_interface", ifnameMesh)
+        assistenttools.statistics_interface_add("collectd_iwinfo", ifnameMesh)
+        assistenttools.statistics_interface_add("collectd_interface", ifnameMesh)
       end
 
       --NETWORK CONFIG mesh
@@ -211,7 +212,7 @@ function main.write(self, section, value)
           ssid=ssid:formvalue(section)
         })
         if statistics_installed then
-          tools.statistics_interface_add("collectd_iwinfo", ifnameAp)
+          assistenttools.statistics_interface_add("collectd_iwinfo", ifnameAp)
         end
       end
 
@@ -258,7 +259,7 @@ function main.write(self, section, value)
 
     -- add to statistics
     if statistics_installed then
-      tools.statistics_interface_add("collectd_interface", "br-dhcp")
+      assistenttools.statistics_interface_add("collectd_interface", "br-dhcp")
     end
 
     --NETWORK CONFIG remove lan bridge because ports a part of dhcp bridge now
@@ -364,7 +365,7 @@ function getchannel(device)
     --this is 5 Ghz
     r_channel = tonumber(uci:get(community, "wifi_device_5", "channel")) or 36
   end
-  tools.logger("channel for device "..device.." is "..tostring(r_channel))
+  assistenttools.logger("channel for device "..device.." is "..tostring(r_channel))
   return r_channel
 end
 
@@ -389,13 +390,13 @@ function calcifcfg(device)
 end
 
 function cleanup(device)
-  tools.wifi_delete_ifaces(device)
-  tools.wifi_delete_ifaces("wlan")
+  assistenttools.wifi_delete_ifaces(device)
+  assistenttools.wifi_delete_ifaces("wlan")
   uci:delete("network", device .. "dhcp")
   uci:delete("network", device)
   local nif = calcnif(device)
-  tools.firewall_zone_remove_interface("freifunk", device)
-  tools.firewall_zone_remove_interface("freifunk", nif)
+  assistenttools.firewall_zone_remove_interface("freifunk", device)
+  assistenttools.firewall_zone_remove_interface("freifunk", nif)
   uci:delete_all("luci_splash", "iface", {network=device.."dhcp", zone="freifunk"})
   uci:delete_all("luci_splash", "iface", {network=nif.."dhcp", zone="freifunk"})
   uci:delete("network", nif .. "dhcp")

--- a/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/olsr.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/olsr.lua
@@ -1,7 +1,7 @@
 local util = require "luci.util"
 local uci = require "luci.model.uci".cursor()
 local ip = require "luci.ip"
-local tools = require "luci.tools.freifunk.assistent.tools"
+local tools = require "luci.tools.freifunk.freifunk-berlin"
 
 local sharenet = uci:get("ffwizard","settings","sharenet")
 local community = "profile_"..uci:get("freifunk", "community", "name")

--- a/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/tools.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/tools/freifunk/assistent/tools.lua
@@ -1,6 +1,5 @@
-local sys = require "luci.sys"
-local util = require "luci.util"
 local uci = require "luci.model.uci".cursor()
+local tools = require "luci.tools.freifunk.freifunk-berlin"
 
 module("luci.tools.freifunk.assistent.tools", package.seeall)
 
@@ -36,7 +35,7 @@ function firewall_zone_remove_interface(name, interface)
 	local zone = firewall_find_zone(name)
 	if zone then
 		local net = cursor:get("firewall", zone, "network")
-		local new = remove_list_entry(net, interface)
+		local new = tools.remove_list_entry(net, interface)
 		if new then
 			if #new > 0 then
 				cursor:set("firewall", zone, "network", new)
@@ -86,61 +85,7 @@ end
 
 
 -- Helpers --
--- Removes a listentry, handles real and pseduo lists transparently
-function remove_list_entry(value, entry)
-	if type(value) == "nil" then
-		return nil
-	end
-
-	local result = type(value) == "table" and value or util.split(value, " ")
-	local key = util.contains(result, entry)
-
-	while key do
-		table.remove(result, key)
-		key = util.contains(result, entry)
-	end
-
-	result = type(value) == "table" and result or table.concat(result, " ")
-	return result ~= value and result
-end
-
 
 function logger(msg)
-        sys.exec("logger -t ffwizard -p 5 '"..msg.."'")
-end
-
---Merge the options of multiple config files into a table.
---
---configs: an array of strings, each representing a config file.  
---  The order is important since  the first config file is read, 
---  then the following.  Any options in the following config files
---  overwrite the values of any previous config files. 
---  e.g. {"freifunk", "profile_berlin"}
---sectionType: the section type to merge. e.g. "defaults"
---sectionName: the section to merge. e.g. "olsrd"
-function getMergedConfig(configs, sectionType, sectionName)
-	local data = {}
-	for i, config in ipairs(configs) do
-		uci:foreach(config, sectionType,
-			function(s)
-				if s['.name'] == sectionName then
-					for key, val in pairs(s) do
-						if string.sub(key, 1, 1) ~= '.' then
-							data[key] = val
-						end
-					end
-				end
-			end)
-		end
-	return data
-end
-
-function mergeInto(config, section, options)
-	local s = uci:get_first(config, section)
-	if (section) then
-		uci:tset(config, s, options)
-	else
-		uci:section(config, section, nil, options)
-	end
-	uci:save(config)
+        tools.logger(msg, "ffwizard", 5)
 end


### PR DESCRIPTION
Move some generic code from the assistent into this new common package.
This way the functions can be used by other code as well.