### PR TITLE
addons: fix building target images with openwrt imagebuilder

### DIFF
--- a/addons/collectd-addons/Makefile
+++ b/addons/collectd-addons/Makefile
@@ -83,7 +83,9 @@ endef
 
 define Package/collectd-dnsmasq-addon/postinst
 #!/bin/sh
+[ -n "$$IPKG_INSTROOT" ] || {
 $${IPKG_INSTROOT}/tmp/collectd-dnsmasq-addon_postinst.sh
+}
 endef
 
 $(eval $(call Download,ubnt_mibs))

--- a/addons/freifunk-berlin-bbbdigger/Makefile
+++ b/addons/freifunk-berlin-bbbdigger/Makefile
@@ -48,7 +48,9 @@ endef
 
 define Package/freifunk-berlin-bbbdigger/postinst
 #!/bin/sh
+[ -n "$$IPKG_INSTROOT" ] || {
 $${IPKG_INSTROOT}/tmp/freifunk-berlin-bbbdigger_postinst.sh
+}
 endef
 
 $(eval $(call BuildPackage,freifunk-berlin-bbbdigger))


### PR DESCRIPTION
Check if we are on "real hardware" or compiling an image with imagebuilder. If we are using imagebuilder the `/lib/functions.sh` is not existing.

This should fix https://github.com/freifunk-berlin/firmware/issues/810.