### PR TITLE
luci-app-ffwizard-berlin: fix insufficient permissions

### DIFF
--- a/utils/luci-app-ffwizard-berlin/root/usr/share/rpcd/acl.d/luci-app-ffwizard-berlin.json
+++ b/utils/luci-app-ffwizard-berlin/root/usr/share/rpcd/acl.d/luci-app-ffwizard-berlin.json
@@ -1,0 +1,80 @@
+{
+        "luci-app-ffwizard-berlin": {
+                "description": "Provides access to config files and scripts",
+                "read": {
+                        "cgi-io": [
+				"exec"
+			],
+                        "uci": [
+                                "profile_*",
+                                "system",
+                                "ffwizard",
+                                "dhcp",
+                                "olsrd",
+                                "olsrd6",
+                                "firewall",
+                                "freifunk",
+                                "wireless",
+                                "network",
+                                "qos",
+                                "luci_statistics",
+                                "openvpn"
+
+                        ],
+                        "files" : {
+                                "/etc/config/ffwizard": [
+                                        "read"
+                                ],
+                                "/etc/luci-uploads/cbid.ffuplink.1.cert": [
+                                        "read"
+                                ],
+                                "/etc/openvpn/ffuplink.crt": [
+                                        "read"
+                                ],
+                                "/etc/luci-uploads/cbid.ffuplink.1.key": [
+                                        "read"
+                                ],
+                                "/etc/openvpn/ffuplink.key": [
+                                        "read"
+                                ],
+                                "/usr/libexec/rpcd/ffwizard-berlin": [
+                                        "exec"
+                                ]
+                        }
+                },
+                "write": {
+                        "uci": [
+                                "profile_*",
+                                "system",
+                                "ffwizard",
+                                "dhcp",
+                                "olsrd",
+                                "olsrd6",
+                                "firewall",
+                                "freifunk",
+                                "wireless",
+                                "network",
+                                "qos",
+                                "luci_statistics",
+                                "openvpn"
+                        ],
+                        "files" : {
+                                "/etc/config/ffwizard": [
+                                        "write"
+                                ],
+                                "/etc/luci-uploads/cbid.ffuplink.1.cert": [
+                                        "write"
+                                ],
+                                "/etc/openvpn/ffuplink.crt": [
+                                        "write"
+                                ],
+                                "/etc/luci-uploads/cbid.ffuplink.1.key": [
+                                        "write"
+                                ],
+                                "/etc/openvpn/ffuplink.key": [
+                                        "write"
+                                ]
+                        }
+                }
+        }
+}


### PR DESCRIPTION
The app tries to access the freifunk community files that are placed at /etc/config/profile_X. If the lua script tries to collect the names it will get an "permission denied" error. The PR gives the lua script the permissions to access the config files.

Fixes: https://github.com/freifunk-berlin/firmware/issues/816