### PR TITLE
luci-mod-freifunk-ui: fix missing dependency

### DIFF
--- a/utils/luci-mod-freifunk-ui/Makefile
+++ b/utils/luci-mod-freifunk-ui/Makefile
@@ -8,9 +8,9 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=Freifunk Public and Admin LuCI UI
-LUCI_DEPENDS:=+luci-mod-admin-full +luci-lib-json +community-profiles +luci-lib-ipkg
+LUCI_DEPENDS:=+luci-mod-admin-full +luci-lib-json +community-profiles +luci-lib-ipkg +luci-compat
 LUCI_PKGARCH:=all
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 include ../../freifunk-berlin-generic.mk
 


### PR DESCRIPTION
If you install the luci-mod-freifunk-ui and click on 'Administration' you will face the erro 'module 'luci.cbi' not found'.

Fix the error by adding luci-compat as dependency.

Fixes: https://github.com/freifunk-berlin/firmware/issues/820