### PR TITLE
luci-mod-freifunk-ui: add rpcd permissions

### DIFF
--- a/utils/luci-mod-freifunk-ui/files/root/usr/share/rpcd/acl.d/luci-mod-freifunk-ui.json
+++ b/utils/luci-mod-freifunk-ui/files/root/usr/share/rpcd/acl.d/luci-mod-freifunk-ui.json
@@ -1,0 +1,85 @@
+{
+        "luci-mod-freifunk-ui": {
+                "description": "Provides access to config files and
+scripts",
+                "read": {
+                        "cgi-io": [
+				"exec"
+			],
+                        "uci": [
+                                "profile_*",
+                                "system",
+                                "ffwizard",
+                                "dhcp",
+                                "olsrd",
+                                "olsrd6",
+                                "firewall",
+                                "freifunk",
+                                "wireless",
+                                "network",
+                                "qos",
+                                "luci_statistics",
+                                "openvpn"
+
+                        ],
+                        "files" : {
+                                "/etc/config/ffwizard": [
+                                        "read"
+                                ],
+                                "/etc/luci-uploads/cbid.ffuplink.1.cert":
+[
+                                        "read"
+                                ],
+                                "/etc/openvpn/ffuplink.crt": [
+                                        "read"
+                                ],
+                                "/etc/luci-uploads/cbid.ffuplink.1.key":
+[
+                                        "read"
+                                ],
+                                "/etc/openvpn/ffuplink.key": [
+                                        "read"
+                                ],
+                                "/usr/libexec/rpcd/ffwizard-berlin": [
+                                        "exec"
+                                ]
+                        }
+                },
+                "write": {
+                        "uci": [
+                                "profile_*",
+                                "system",
+                                "ffwizard",
+                                "dhcp",
+                                "olsrd",
+                                "olsrd6",
+                                "firewall",
+                                "freifunk",
+                                "wireless",
+                                "network",
+                                "qos",
+                                "luci_statistics",
+                                "openvpn"
+                        ],
+                        "files" : {
+                                "/etc/config/ffwizard": [
+                                        "write"
+                                ],
+                                "/etc/luci-uploads/cbid.ffuplink.1.cert":
+[
+                                        "write"
+                                ],
+                                "/etc/openvpn/ffuplink.crt": [
+                                        "write"
+                                ],
+                                "/etc/luci-uploads/cbid.ffuplink.1.key":
+[
+                                        "write"
+                                ],
+                                "/etc/openvpn/ffuplink.key": [
+                                        "write"
+                                ]
+                        }
+                }
+        }
+}


### PR DESCRIPTION
Add the necessary permissions for accessing the files and scripts.

A part of: https://github.com/freifunk-berlin/firmware/issues/818

**THIS IS A DRAFT, PERMISSIONS HAVE TO BE REMOVED**