### PR TITLE
luci-mod-freifunk-ui: fix collecting of community names

### DIFF
--- a/utils/luci-mod-freifunk-ui/Makefile
+++ b/utils/luci-mod-freifunk-ui/Makefile
@@ -10,7 +10,7 @@ include $(TOPDIR)/rules.mk
 LUCI_TITLE:=Freifunk Public and Admin LuCI UI
 LUCI_DEPENDS:=+luci-mod-admin-full +luci-lib-json +community-profiles +luci-lib-ipkg
 LUCI_PKGARCH:=all
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 include ../../freifunk-berlin-generic.mk
 

--- a/utils/luci-mod-freifunk-ui/luasrc/model/cbi/freifunk/basics.lua
+++ b/utils/luci-mod-freifunk-ui/luasrc/model/cbi/freifunk/basics.lua
@@ -15,10 +15,10 @@ community.rmempty = false
 
 local profile
 for profile in fs.glob(profiles) do
-	local name = uci:get_first(profile, "community", "name") or "?"
-	community:value(string.gsub(profile, "/etc/config/profile_", ""), name)
+	local n = string.gsub(profile, "/etc/config/profile_", "")
+	local name = uci:get_first("profile_"..n, "community", "name") or "?"
+	community:value(n, name)
 end
-
 
 n = Map("system", translate("Basic system settings"))
 function n.on_after_commit(self)


### PR DESCRIPTION
You can not give uci a full path.

Fixes: https://github.com/freifunk-berlin/firmware/issues/821