### PR TITLE
bbbdigger: depend on olsrd

### DIFF
--- a/addons/freifunk-berlin-bbbdigger/Makefile
+++ b/addons/freifunk-berlin-bbbdigger/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=freifunk-berlin-bbbdigger
 PKG_VERSION:=0.0.3
-PKG_RELEASE:=0
+PKG_RELEASE:=1
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)
 
@@ -25,7 +25,7 @@ endef
 define Package/freifunk-berlin-bbbdigger
   $(call Package/freifunk-berlin-bbbdigger/default)
   TITLE:=A Tunneldigger (l2tp) based VPN connection to mesh with the Berlin Backbone
-  DEPENDS:=+freifunk-berlin-tunneldigger
+  DEPENDS:=+freifunk-berlin-tunneldigger +olsrd
 endef
 
 define Package/freifunk-berlin-bbbdigger/description


### PR DESCRIPTION
OLSRv1 is the spoken protocol on the BBB-VPN, so olsrd is a logical dependency.