### PR TITLE
dnsmasq ignore br-wan ffuplink_wan

### DIFF
--- a/defaults/freifunk-berlin-dhcp-defaults/uci-defaults/freifunk-berlin-dhcp-defaults
+++ b/defaults/freifunk-berlin-dhcp-defaults/uci-defaults/freifunk-berlin-dhcp-defaults
@@ -6,6 +6,9 @@ guard "dhcp"
 # quieten down dnsmasq a bit (do not log lease-mgmt)
 uci set dhcp.@dnsmasq[0].quietdhcp=1
 
+# dnsmasq should not care for 'br-wan ffuplink_wan', prevents: daemon.warn dnsmasq-dhcp: DHCP packet received on xxx_wan which has no address
+uci set dhcp.@dnsmasq[0].notinterface='br-wan ffuplink_wan'
+
 # on IPv6-islands we also should give a default-route to the clients,
 # so they can also reach IPv6-neighbours. 
 uci set dhcp.dhcp.ra_default=1


### PR DESCRIPTION
**What is the problem?**
syslog is spammed by: daemon.warn dnsmasq-dhcp: DHCP packet received on xxx_wan which has no address

**What is the expected behaviour?**
dnsmasq should not care / be silent for 'br-wan ffuplink_wan'