### PR TITLE
addons/snmp: correct some labels for Ubiquiti AirMax

### DIFF
--- a/addons/collectd-addons/files/collectd-snmp/ubnt-airmax.conf
+++ b/addons/collectd-addons/files/collectd-snmp/ubnt-airmax.conf
@@ -11,7 +11,7 @@ LoadPlugin snmp
     <Data "rf_signalstrength">
 	Type "signal_power"
 	Table false
-	Instance "rx-power"
+	Instance "rx-level"
 	Values ".1.3.6.1.4.1.41112.1.4.5.1.5.1"
     </Data>
     <Data "rf_signalrssi">
@@ -54,7 +54,7 @@ LoadPlugin snmp
     <Data "rf_power_tx">
 	Type "gauge"
 	Table false
-	Instance "tx_power"
+	Instance "tx_power (dBm)"
 	Values ".1.3.6.1.4.1.41112.1.4.1.1.6.1"
     </Data>
     <Data "rf_channelwidth">
@@ -67,7 +67,7 @@ LoadPlugin snmp
     <Data "rf_ubntWlStatRssi">
 	Type "gauge"
 	Table false
-	Instance "RSSI (dBm)"
+	Instance "RSSI"
 	Values ".1.3.6.1.4.1.41112.1.4.5.1.6.1"
     </Data>
 


### PR DESCRIPTION
Running SNMP-Monitoring of a NanoBeam AC (http://monitor.berlin.freifunk.net/host.php?h=Verklaerung-core&p=snmp) shows that some labels are wrong / misleading, so fix this.

* change rx-power to rx-level
* suffix tx-power by unit "dBm"

![update airMax-labels](https://user-images.githubusercontent.com/1755362/97056454-58d52a80-1589-11eb-908e-f576a3ee1eb0.jpeg)
