### PR TITLE
GHA/pr-conflicts: run on push and pull-request of master

### DIFF
--- a/.github/workflows/pr-conflicts.yml
+++ b/.github/workflows/pr-conflicts.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    types: [ synchronize, ready_for_review ]
+    types: [ opened, synchronize, ready_for_review, reopened]
     branches: [ master ]
 
 jobs:

--- a/.github/workflows/pr-conflicts.yml
+++ b/.github/workflows/pr-conflicts.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
+    types: [ synchronize, ready_for_review ]
     branches: [ master ]
 
 jobs:

--- a/.github/workflows/pr-conflicts.yml
+++ b/.github/workflows/pr-conflicts.yml
@@ -3,6 +3,8 @@ name: Check PRs for conflict
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   triage:


### PR DESCRIPTION
It seems useful, that even a PR against master triggers a check for conflicts.