### PR TITLE
Wizard: update test for general-Info snippet

### DIFF
--- a/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/generalInfo.htm
+++ b/utils/luci-app-ffwizard-berlin/luasrc/view/freifunk/assistent/snippets/generalInfo.htm
@@ -7,10 +7,15 @@
     angezeigt. So k&ouml;nnen dich andere Freifunkerinnen finden und
     dich ansprechen, falls sie Ihren Router mit deinem verbinden
     m&ouml;chten.
-    <br/>Falls du hier nichts angeben möchtest, kannst du den
-    Punkt auch einfach &uuml;berspringen oder einzelne Felder leerlassen.
-    <br/>Den (eindeutigen) Namen dieses Freifunk-Knotens musst du
-    allerdings setzen.
+    <br/>Falls du hier deine EMail-Adresse nichts angeben möchtest, 
+    kannst du den auch den Kontakt-Link, den du bei der Registrierung 
+    deiner IP-Adressen bekommen hast oder einen beliebigen anderen 
+    Link eingeben.
+    <br/>Wenn du zu einem Punkt keine Angaben machen willst, kannst du 
+    das Feld auch einfach &uuml;berspringen und leerlassen.
+    <br/>Den (eindeutigen) Namen dieses Freifunk-Knotens kannst du auch
+    festlegen, wenn du das nicht willst, wird er automatisch aus deiner 
+    reservierten IP-Adresse erzeugt.
     <br/>Du kannst diese Daten auch später noch ändern, indem du nur
     diese Seite des Assistenten benutzt.
   </p>


### PR DESCRIPTION
* add hint to insert contact-link from registration-wizard
* add hint for automatically generated nodename if not supplied by user

A lot of new nodes do not supply a contact-info. Add a hint that also http-links will be accepted. This is esp. relevant for the contactlink generated by the IP-registration.
So we hopefully decrease the number of "uncontactable" nodes again.