### PR TITLE
adapt network-configuration to changed UCI-syntax

### DIFF
--- a/defaults/freifunk-berlin-network-defaults/root/etc/uci-defaults/freifunk-berlin-network-defaults
+++ b/defaults/freifunk-berlin-network-defaults/root/etc/uci-defaults/freifunk-berlin-network-defaults
@@ -1,7 +1,36 @@
 #!/bin/sh
 
+. /lib/functions.sh
 . /lib/functions/guard.sh
 guard "network"
+
+# find_first_section_for_name(sectionname uci-config searchname)
+find_first_section_for_name() {
+  local section=$1
+  local uciconfig=$2
+  local search=$3
+
+  if [ $(uci -q get ${uciconfig}.${section}.name) = ${search} ]; then
+    echo ${section}
+    return 0
+  fi
+}
+
+wan_2_bridge() {
+  local WANDEVICE=$1
+  local WANDEVICESECTION
+
+  # find current WAN-device
+  config_load network
+  WANDEVICESECTION=$(config_foreach find_first_section_for_name device network ${WANDEVICE})
+  # define WAN-device as bridge with name "br-wan"
+  uci set network.$WANDEVICESECTION.type='bridge'
+  uci add_list network.$WANDEVICESECTION.ports=$(uci get network.$WANDEVICESECTION.name)
+  uci set network.$WANDEVICESECTION.name='br-wan'
+  # set WAN & WAN6 interfaces to new WAN-device
+  uci set network.wan.device="br-wan"
+  uci set network.wan6.device="br-wan"
+}
 
 # change default ip to avoid collision with user's local network
 uci set network.lan.ipaddr=192.168.42.1
@@ -11,8 +40,9 @@ uci set network.lan.ipaddr=192.168.42.1
 uci set network.wan.peerdns=0
 uci set network.wan6.peerdns=0
 
-# setup wan as bridge
-uci set network.wan.type=bridge
+# setup wan as bridge if it exists (e.g. 1-port devices)
+#  "network.wan.device" is usually "eth0.2"
+uci -q get network.wan >/dev/null && wan_2_bridge $(uci get network.wan.device)
 
 # add tunl0 interface - tunl0 is the ipip tunnel interface for the olsr
 # SmartGateway plugin

--- a/uplinks/freifunk-berlin-uplink-notunnel/root/etc/uci-defaults/freifunk-berlin-z95_notunnel
+++ b/uplinks/freifunk-berlin-uplink-notunnel/root/etc/uci-defaults/freifunk-berlin-z95_notunnel
@@ -42,9 +42,22 @@ uci set network.ffuplink_dev.macaddr=$macaddr
 uci commit network.ffuplink_dev
 
 # add ffuplink_dev to br-wan if not there
-ifnames=$(uci get network.wan.ifname)
-list_contains ifnames ffuplink_wan || uci set network.wan.ifname="${ifnames} ffuplink_wan"
-uci commit network.wan
+## look for our uci-device section and add the kernel-device as bridge-port
+add_kernelif_to_bridge() {
+  local section="$1"
+  local device="$2"
+  local kernelif="$3"
+
+  local thisdevice=$(uci get network.$section.name)
+  if [ "$device" = "$thisdevice" ]; then
+    ifnames=$(uci -q get network.$section.ports)
+    list_contains ifnames "$kernelif" || uci add_list network.$section.ports=$kernelif
+    uci commit network.$section
+  fi
+}
+
+config_load network
+config_foreach add_kernelif_to_bridge device br-wan ffuplink_wan
 
 uci set network.ffuplink.proto=dhcp
 uci set network.ffuplink.hostname=freifunk-$(echo $macaddr|tr -d :)-uplink

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -255,13 +255,6 @@ function main.write(self, section, value)
     prenetconfig.proto="static"
     prenetconfig.ifname="br-dhcp"
 
-    -- if macaddr is set for lan interface also set it for dhcp interface (needed for wdr4900)
-    -- TODO: rewite to new network --> is it needed? the MAC should belong to the still correct device
-    local macaddr=uci:get("network", "lan", "macaddr") or uci:get("network", "dhcp", "macaddr")
-    if (macaddr) then
-      prenetconfig.macaddr = macaddr
-    end
-
     uci:section("network", "interface", "dhcp", prenetconfig)
 
     -- add to statistics

--- a/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/model/cbi/freifunk/assistent/wireless.lua
@@ -239,16 +239,24 @@ function main.write(self, section, value)
   --only do this if user entered cidr
   if (dhcpmeshnet:prefix() < 32) then
     --NETWORK CONFIG bridge for wifi APs
+    -- rename device br-lan to br-dhcp
+    uci:foreach("network","device",
+      function(section)
+        if section.name == "br-lan" then
+          uci:set("network", section['.name'], "name", "br-dhcp")
+        end
+      end
+    )
+
     local prenetconfig =  {}
     prenetconfig.ipaddr=dhcpmeshnet:minhost():string()
     prenetconfig.netmask=dhcpmeshnet:mask():string()
     prenetconfig.ip6assign="64"
-    prenetconfig.type="bridge"
     prenetconfig.proto="static"
-    -- use ifname from dhcp bridge on a consecutive run of assistent
-    prenetconfig.ifname=uci:get("network", "lan", "ifname") or uci:get("network", "dhcp", "ifname")
+    prenetconfig.ifname="br-dhcp"
 
     -- if macaddr is set for lan interface also set it for dhcp interface (needed for wdr4900)
+    -- TODO: rewite to new network --> is it needed? the MAC should belong to the still correct device
     local macaddr=uci:get("network", "lan", "macaddr") or uci:get("network", "dhcp", "macaddr")
     if (macaddr) then
       prenetconfig.macaddr = macaddr


### PR DESCRIPTION
Adapt our network-setup to OpenWrts change of the way bridges are defined from OpenWrt-21.02.0-rc2 onwards. (See: openwrt/openwrt@892fc7c)

This applies to "network-defaults" and "uplink-notunnel" for br-wan, "wizard" for br-dhcp. 

Tested the on a WDR3600, <strike>a test on a WDR-4900 (or any other device having a MAC-address defined) will be really great (fd3390a39623e48aa4fe24bb56a3bacb4e729497)</strike>.