### PR TITLE
use "redirect_landingurl" feature of mod-freifunk to bring up wizard on 1st-boot

### DIFF
--- a/utils/luci-app-ffwizard-berlin/Makefile
+++ b/utils/luci-app-ffwizard-berlin/Makefile
@@ -6,6 +6,12 @@ LUCI_TITLE:=Freifunk Berlin configuration wizard
 LUCI_DEPENDS:=+luci-compat +luci-mod-admin-full +freifunk-policyrouting +luci-lib-jsonc +community-profiles +luci-lib-ipkg
 PKG_RELEASE:=5
 
+define Package/luci-app-ffwizard-berlin/postrm
+#!/bin/sh
+[ '/cgi-bin/luci/admin/freifunk/assistent?luci_username=root&luci_password=' = "$$(uci -q get freifunk.luci.redirect_landingurl)" ] &&
+  { uci delete freifunk.luci.redirect_landingurl; uci commit freifunk.luci; }
+endef
+
 include ../../freifunk-berlin-generic.mk
 
 # call BuildPackage - OpenWrt buildroot signature

--- a/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
+++ b/utils/luci-app-ffwizard-berlin/luasrc/controller/assistent/assistent.lua
@@ -45,6 +45,9 @@ function commit()
 
   uci:set("ffwizard","settings","runbefore","true")
   uci:save("ffwizard")
+  -- remove landingpage redirection of luci-mod-freifunk, to restore default behavior
+  uci:set('freifunk', 'luci', 'redirect_landingurl', '')
+
   local sharenet = uci:get("ffwizard","settings","sharenet")
 
   local community = "profile_"..uci:get("freifunk","community","name")
@@ -150,6 +153,10 @@ function reset()
   uci:set("ffwizard","settings","runbefore","true")
   uci:save("ffwizard")
   uci:commit("ffwizard")
+  -- remove landingpage redirection of luci-mod-freifunk, to restore default behavior
+  uci:set('freifunk', 'luci', 'redirect_landingurl', '')
+  uci:save('freifunk')
+  uci:commit('freifunk', 'luci')
 
   luci.http.redirect(luci.dispatcher.build_url("/"))
 end

--- a/utils/luci-app-ffwizard-berlin/root/etc/uci-defaults/wizarddefaults
+++ b/utils/luci-app-ffwizard-berlin/root/etc/uci-defaults/wizarddefaults
@@ -6,3 +6,9 @@ uci set freifunk-policyrouting.pr.enable=1
 uci set freifunk-policyrouting.pr.fallback=0
 uci set freifunk-policyrouting.pr.zones="freifunk"
 uci commit freifunk-policyrouting
+
+# redirect to wizard when it has never run before, will be removed when the wizard has finished
+[ 'true' = "$(uci -q get ffwizard.settings.runbefore)" ] && exit 0
+uci set freifunk.luci=setting
+uci set freifunk.luci.redirect_landingurl='/cgi-bin/luci/admin/freifunk/assistent?luci_username=root&luci_password='
+uci commit freifunk.luci


### PR DESCRIPTION
The luci-mod-freifunk has the new feature to redirect to a custom page when LuCI is called without an explicit page (https://github.com/freifunk/openwrt-packages/commit/21e69cd27d736f13295e2af79108617ccc694b45). Let's use this to redirect to the wizard and remove the redirection again when the wizard has finished.
This way we don't need the "redirect on firstboot" patch (up to Kathleen 0.1.2) and can also drop our forked "luci-mod-freifunk-ui" package, which is basically the same package with the mentioned patch included.
