### PR TITLE
firewall-defaults: use "uci lists" in place of "uci option" for network and devices

### DIFF
--- a/defaults/freifunk-berlin-firewall-defaults/root/etc/uci-defaults/freifunk-berlin-firewall-defaults
+++ b/defaults/freifunk-berlin-firewall-defaults/root/etc/uci-defaults/freifunk-berlin-firewall-defaults
@@ -82,7 +82,7 @@ uci set firewall.zone_freifunk.forward=REJECT
 uci set firewall.zone_freifunk.name=freifunk
 uci set firewall.zone_freifunk.output=ACCEPT
 uci add_list firewall.zone_freifunk.network=tunl0
-uci set firewall.zone_freifunk.device=tnl_+
+uci add_list firewall.zone_freifunk.device=tnl_+
 
 # add named zone section for the uplink of client-traffic
 uci set firewall.zone_ffuplink=zone

--- a/defaults/freifunk-berlin-firewall-defaults/root/etc/uci-defaults/freifunk-berlin-firewall-defaults
+++ b/defaults/freifunk-berlin-firewall-defaults/root/etc/uci-defaults/freifunk-berlin-firewall-defaults
@@ -81,7 +81,7 @@ uci set firewall.zone_freifunk.input=ACCEPT
 uci set firewall.zone_freifunk.forward=REJECT
 uci set firewall.zone_freifunk.name=freifunk
 uci set firewall.zone_freifunk.output=ACCEPT
-uci set firewall.zone_freifunk.network=tunl0
+uci add_list firewall.zone_freifunk.network=tunl0
 uci set firewall.zone_freifunk.device=tnl_+
 
 # add named zone section for the uplink of client-traffic
@@ -90,7 +90,7 @@ uci set firewall.zone_ffuplink.name=ffuplink
 uci set firewall.zone_ffuplink.input=REJECT
 uci set firewall.zone_ffuplink.forward=ACCEPT
 uci set firewall.zone_ffuplink.output=ACCEPT
-uci set firewall.zone_ffuplink.network=ffuplink
+uci add_list firewall.zone_ffuplink.network=ffuplink
 uci set firewall.zone_ffuplink.masq=1
 
 FORWARDING="$(uci add firewall forwarding)"


### PR DESCRIPTION
OpenWrt changed to use a "uci list" for multi-paramerter items, in stead using a "uci option" with space-separated items. This applies for 'zone.devices', 'zone.network' (interfaces), 'rule.icmp-types' and possibly more. This changed syntax is indeed more correct for such list of items.

Updating the defaults-package to the new syntax is straight forward. But this will likely cause errors in packages relying on the firewall-setup. These packages (e.g. uplinks, wizard) expect the space-separated uci-option and will probably fail on the uci lists.

As the old options-format is still supported, there is no urgent need to change. At some point it might to become an issue that need to get addressed. For now I'll just publish the the change of the defaults-package and postpone the required follow-up changes (to someone else).