### PR TITLE
migration: drop "clean_jffs" script

### DIFF
--- a/utils/freifunk-berlin-migration/uci-defaults/zz_freifunk-berlin-migration-clean_jffs.sh
+++ b/utils/freifunk-berlin-migration/uci-defaults/zz_freifunk-berlin-migration-clean_jffs.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-
-# delete any overlay config files duplicated from romfs by sysupgrade - saves JFFS2 space
-cd /overlay/upper/etc/config/ && for i in *; do [ -f "$i" ] && if cmp -s "$i" "/rom/etc/config/$i"; then rm -f "$i"; fi; done;


### PR DESCRIPTION
This script was causing several issues and is not needed since we are doing `sysupgrade -k` always. (`-k` prevent adding unchanged files into the backup-archive)
* https://github.com/freifunk-berlin/firmware/issues/641
* https://github.com/freifunk-berlin/firmware-packages/commit/cd0e613192906b95dce11ffbeb654ca278036f8e