### PR TITLE
Control PoE ports on the UniFi Flex switch

### DIFF
--- a/utils/poemgr/Makefile
+++ b/utils/poemgr/Makefile
@@ -1,0 +1,33 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=poemgr
+PKG_VERSION:=$(shell git show -s --format=%cd --date=short)
+PKG_RELEASE:=1
+
+PKG_FILE_DEPENDS:=$(CURDIR)/../..
+
+include $(INCLUDE_DIR)/package.mk
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+	cp -R $(CURDIR)/../../* $(PKG_BUILD_DIR)
+endef
+
+define Package/poemgr
+  SECTION:=utils
+  CATEGORY:=Utilities
+  DEPENDS:=+libuci +libjson-c
+  TITLE:=Control PoE ports on the UniFi Flex switch
+endef
+
+define Package/poemgr/install
+	$(INSTALL_DIR) $(1)/sbin $(1)/usr/lib/poemgr/config $(1)/etc/config $(1)/etc/uci-defaults $(1)/etc/init.d
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/poemgr $(1)/sbin/poemgr
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/uswlite-pse-enable $(1)/usr/lib/poemgr/uswlite-pse-enable
+	$(CP) $(PKG_BUILD_DIR)/contrib/usw-lite.config $(1)/usr/lib/poemgr/config/usw-lite.config
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/uci-defaults.sh $(1)/etc/uci-defaults/99-poemgr
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/procd-init.sh $(1)/etc/init.d/poemgr
+endef
+
+
+$(eval $(call BuildPackage,poemgr))

--- a/utils/poemgr/Makefile
+++ b/utils/poemgr/Makefile
@@ -1,17 +1,19 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=poemgr
-PKG_VERSION:=$(shell git show -s --format=%cd --date=short)
+PKG_VERSION:=0.0.0
 PKG_RELEASE:=1
 
-PKG_FILE_DEPENDS:=$(CURDIR)/../..
+# Switch back to original github.com/blocktrron/poemgr when patch is merged
+PKG_SOURCE_PROTO:=git
+PKG_SOURCE_URL:=https://github.com/pktpls/poemgr.git
+PKG_SOURCE_DATE:=2022-03-19
+PKG_SOURCE_VERSION:=b5dc3935142a04eacc43b918f0d4cd61af634619
+
+PKG_MAINTAINER:=David Bauer <mail@david-bauer.net>
+PKG_LICENSE:=GPL-2.0-only
 
 include $(INCLUDE_DIR)/package.mk
-
-define Build/Prepare
-	mkdir -p $(PKG_BUILD_DIR)
-	cp -R $(CURDIR)/../../* $(PKG_BUILD_DIR)
-endef
 
 define Package/poemgr
   SECTION:=utils
@@ -23,10 +25,10 @@ endef
 define Package/poemgr/install
 	$(INSTALL_DIR) $(1)/sbin $(1)/usr/lib/poemgr/config $(1)/etc/config $(1)/etc/uci-defaults $(1)/etc/init.d
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/poemgr $(1)/sbin/poemgr
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/uswlite-pse-enable $(1)/usr/lib/poemgr/uswlite-pse-enable
-	$(CP) $(PKG_BUILD_DIR)/contrib/usw-lite.config $(1)/usr/lib/poemgr/config/usw-lite.config
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/uci-defaults.sh $(1)/etc/uci-defaults/99-poemgr
-	$(INSTALL_BIN) $(PKG_BUILD_DIR)/contrib/procd-init.sh $(1)/etc/init.d/poemgr
+	$(INSTALL_BIN) ./files/uswlite-pse-enable $(1)/usr/lib/poemgr/uswlite-pse-enable
+	$(CP) ./files/usw-lite.config $(1)/usr/lib/poemgr/config/usw-lite.config
+	$(INSTALL_BIN) ./files/uci-defaults.sh $(1)/etc/uci-defaults/99-poemgr
+	$(INSTALL_BIN) ./files/procd-init.sh $(1)/etc/init.d/poemgr
 endef
 
 

--- a/utils/poemgr/files/procd-init.sh
+++ b/utils/poemgr/files/procd-init.sh
@@ -1,0 +1,36 @@
+#!/bin/sh /etc/rc.common
+
+START=80
+USE_PROCD=1
+
+NAME=poemgr
+PROG=/sbin/poemgr
+
+. /lib/functions.sh
+
+
+reload_service() {
+	start
+}
+
+service_triggers() {
+	procd_add_reload_trigger poemgr
+}
+
+stop_service()
+{
+	$PROG disable
+}
+
+start_service()
+{
+	DISABLED="$(uci -q get poemgr.settings.disabled)"
+	DISABLED="${DISABLED:-0}"
+
+	if [ "$DISABLED" -gt 0 ]
+	then
+		$PROG disable
+	else
+		$PROG apply
+	fi
+}

--- a/utils/poemgr/files/uci-defaults.sh
+++ b/utils/poemgr/files/uci-defaults.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+[ -e /etc/config/poemgr ] && exit 0
+
+. /lib/functions/uci-defaults.sh
+
+board=$(board_name)
+case "$board" in
+ubnt,usw-flex)
+    cp /usr/lib/poemgr/usw-flex.config /etc/config/poemgr
+    ;;
+esac

--- a/utils/poemgr/files/usw-lite.config
+++ b/utils/poemgr/files/usw-lite.config
@@ -1,0 +1,23 @@
+config poemgr 'settings'
+        option profile 'usw-flex'
+        option disabled '1'
+
+config port 'lan2'
+        option name 'lan2'
+        option port '3'
+        option disabled '1'
+
+config port 'lan3'
+        option name 'lan3'
+        option port '2'
+        option disabled '1'
+
+config port 'lan4'
+        option name 'lan4'
+        option port '1'
+        option disabled '1'
+
+config port 'lan5'
+        option name 'lan5'
+        option port '0'
+        option disabled '1'

--- a/utils/poemgr/files/uswlite-pse-enable
+++ b/utils/poemgr/files/uswlite-pse-enable
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+echo 487 > /sys/class/gpio/export # JK
+echo 488 > /sys/class/gpio/export # CLK
+
+echo out > /sys/class/gpio/gpio487/direction
+echo out > /sys/class/gpio/gpio488/direction
+
+echo $1 > /sys/class/gpio/gpio487/value
+echo 0 > /sys/class/gpio/gpio488/value
+echo 1 > /sys/class/gpio/gpio488/value


### PR DESCRIPTION
Das ist ein Import des `poemgr` Pakets von @blocktrron, das noch keinem sonstigen Feed zugeordnet ist. Auf lange Sicht wäre es sicher gut, wenn das Paket im packages-Feed landet, dann kann es hier wieder entfernt werden.

Jetzt gerade nutzt es noch meinen poemgr-Fork, der einen wichtigen Fix fürs PoE Power Budget enthält.

Ich brauchs für den Unifi Switch Flex, ein Outdoor 4-Port-PoE-Switch, mglw. eine Alternative zum Edgepoint R6, der auf absehbare Zeit nicht lieferbar ist.